### PR TITLE
doc: add basic java docs and java doc maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,20 @@ SPDX-License-Identifier: Apache-2.0
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
                 <version>1.0.2</version>

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocEd25519VerificationKey2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocEd25519VerificationKey2020.java
@@ -43,7 +43,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.VerificationMethod;
 public class BuildDIDDocEd25519VerificationKey2020 {
 
   /**
-   * Build did document did document.
+   * Build did document
    *
    * @param hostName the host name
    * @return the did document

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocEd25519VerificationKey2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocEd25519VerificationKey2020.java
@@ -39,7 +39,16 @@ import org.eclipse.tractusx.ssi.lib.model.did.Ed25519VerificationMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.Ed25519VerificationMethodBuilder;
 import org.eclipse.tractusx.ssi.lib.model.did.VerificationMethod;
 
+/** This is example class to demonstrate how to create @{@link DidDocument} using Ed25519 key */
 public class BuildDIDDocEd25519VerificationKey2020 {
+
+  /**
+   * Build did document did document.
+   *
+   * @param hostName the host name
+   * @return the did document
+   * @throws KeyGenerationException the key generation exception
+   */
   public static DidDocument buildDidDocument(String hostName) throws KeyGenerationException {
     final Did did = DidWebFactory.fromHostname(hostName);
 

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocJsonWebKey2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocJsonWebKey2020.java
@@ -40,7 +40,14 @@ import org.eclipse.tractusx.ssi.lib.model.did.JWKVerificationMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.JWKVerificationMethodBuilder;
 import org.eclipse.tractusx.ssi.lib.model.did.VerificationMethod;
 
+/** This is example class to demonstrate how to create @{@link DidDocument} using Json web key */
 public class BuildDIDDocJsonWebKey2020 {
+  /**
+   * Build did document did document.
+   *
+   * @param hostName the host name
+   * @return the did document
+   */
   @SneakyThrows
   public static DidDocument buildDidDocument(String hostName) {
     // Building DID and Key

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocJsonWebKey2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/BuildDIDDocJsonWebKey2020.java
@@ -43,7 +43,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.VerificationMethod;
 /** This is example class to demonstrate how to create @{@link DidDocument} using Json web key */
 public class BuildDIDDocJsonWebKey2020 {
   /**
-   * Build did document did document.
+   * Build did document.
    *
    * @param hostName the host name
    * @return the did document

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
@@ -31,7 +31,16 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** This is example class to demonstrate did document resolve from given did web url */
 public class ResolveDIDDoc {
+  /**
+   * Resovle document did document.
+   *
+   * @param didUrl the did url
+   * @return the did document
+   * @throws DidDocumentResolverNotRegisteredException the did document resolver not registered
+   *     exception
+   */
   public static DidDocument ResovleDocument(String didUrl)
       throws DidDocumentResolverNotRegisteredException {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
@@ -31,7 +31,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
-/** This is example class to demonstrate did document resolve from given did web url */
+/** This is an example class to demonstrate did document resolve from given did web url */
 public class ResolveDIDDoc {
   /**
    * Resolve did document.

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
@@ -34,7 +34,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 /** This is example class to demonstrate did document resolve from given did web url */
 public class ResolveDIDDoc {
   /**
-   * Resovle document did document.
+   * Resolve  did document.
    *
    * @param didUrl the did url
    * @return the did document

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/ResolveDIDDoc.java
@@ -34,7 +34,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 /** This is example class to demonstrate did document resolve from given did web url */
 public class ResolveDIDDoc {
   /**
-   * Resolve  did document.
+   * Resolve did document.
    *
    * @param didUrl the did url
    * @return the did document

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
@@ -39,7 +39,13 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofGenerator;
 import org.eclipse.tractusx.ssi.lib.proof.SignatureType;
 
+/** This is example class to demonstrate how create Verifiable Credentials */
 public class VC {
+  /**
+   * Create vc without proof verifiable credential.
+   *
+   * @return the verifiable credential
+   */
   public static VerifiableCredential createVCWithoutProof() {
 
     // VC Bulider
@@ -64,6 +70,17 @@ public class VC {
     return credentialWithoutProof;
   }
 
+  /**
+   * Create vc with ed 21559 proof verifiable credential.
+   *
+   * @param credential the credential
+   * @param privateKey the private key
+   * @param issuer the issuer
+   * @return the verifiable credential
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws SsiException the ssi exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   */
   public static VerifiableCredential createVCWithED21559Proof(
       VerifiableCredential credential, IPrivateKey privateKey, Did issuer)
       throws UnsupportedSignatureTypeException, SsiException, InvalidePrivateKeyFormat {
@@ -92,6 +109,17 @@ public class VC {
     return builder.build();
   }
 
+  /**
+   * Create vc with jws proof verifiable credential.
+   *
+   * @param credential the credential
+   * @param privateKey the private key
+   * @param issuer the issuer
+   * @return the verifiable credential
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws SsiException the ssi exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   */
   public static VerifiableCredential createVCWithJWSProof(
       VerifiableCredential credential, IPrivateKey privateKey, Did issuer)
       throws UnsupportedSignatureTypeException, SsiException, InvalidePrivateKeyFormat {

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
@@ -71,7 +71,7 @@ public class VC {
   }
 
   /**
-   * Create verifiable credential. with ed 21559 proof
+   * Create verifiable credential. with ED21559 proof
    *
    * @param credential the credential
    * @param privateKey the private key

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
@@ -42,7 +42,7 @@ import org.eclipse.tractusx.ssi.lib.proof.SignatureType;
 /** This is example class to demonstrate how create Verifiable Credentials */
 public class VC {
   /**
-   * Create vc without proof verifiable credential.
+   * Create verifiable credential without proof
    *
    * @return the verifiable credential
    */
@@ -71,7 +71,7 @@ public class VC {
   }
 
   /**
-   * Create vc with ed 21559 proof verifiable credential.
+   * Create verifiable credential. with ed 21559 proof
    *
    * @param credential the credential
    * @param privateKey the private key

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VC.java
@@ -71,7 +71,7 @@ public class VC {
   }
 
   /**
-   * Create verifiable credential. with ED21559 proof
+   * Create verifiable credential with ED21559 proof
    *
    * @param credential the credential
    * @param privateKey the private key

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
@@ -38,12 +38,12 @@ import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationF
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactoryImpl;
 
 /**
- * This is example class to demonstrate how create Verifiable Presentation in JSON-LD and KWT format
+ * his is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and KWT format
  */
 class VP {
 
   /**
-   * Create vp verifiable presentation.
+   * Create verifiable presentation.
    *
    * @param issuer the issuer
    * @param credentials the credentials
@@ -63,7 +63,7 @@ class VP {
   }
 
   /**
-   * Create vp as jwt signed jwt.
+   * Create vp as a signed jwt.
    *
    * @param issuer the issuer
    * @param credentials the credentials

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
@@ -37,8 +37,18 @@ import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.JsonLdSerializerImpl;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactory;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactoryImpl;
 
+/**
+ * This is example class to demonstrate how create Verifiable Presentation in JSON-LD and KWT format
+ */
 class VP {
 
+  /**
+   * Create vp verifiable presentation.
+   *
+   * @param issuer the issuer
+   * @param credentials the credentials
+   * @return the verifiable presentation
+   */
   public static VerifiablePresentation createVP(
       Did issuer, List<VerifiableCredential> credentials) {
     final VerifiablePresentationBuilder verifiablePresentationBuilder =
@@ -52,6 +62,17 @@ class VP {
     return verifiablePresentation;
   }
 
+  /**
+   * Create vp as jwt signed jwt.
+   *
+   * @param issuer the issuer
+   * @param credentials the credentials
+   * @param audience the audience
+   * @param privateKey the private key
+   * @param publicKey the public key
+   * @return the signed jwt
+   * @throws IOException the io exception
+   */
   public static SignedJWT createVPAsJWT(
       Did issuer,
       List<VerifiableCredential> credentials,

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
@@ -38,7 +38,8 @@ import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationF
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactoryImpl;
 
 /**
- * his is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and KWT format
+ * his is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and KWT
+ * format
  */
 class VP {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
@@ -38,13 +38,13 @@ import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationF
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationFactoryImpl;
 
 /**
- * his is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and KWT
- * format
+ * This is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and
+ * KWT format
  */
 class VP {
 
   /**
-   * Create verifiable presentation.
+   * Create a verifiable presentation.
    *
    * @param issuer the issuer
    * @param credentials the credentials

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/VP.java
@@ -39,7 +39,7 @@ import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedJwtPresentationF
 
 /**
  * This is an example class to demonstrate how to create a Verifiable Presentation in JSON-LD and
- * KWT format
+ * JWT format
  */
 class VP {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/Validation.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/Validation.java
@@ -26,13 +26,30 @@ import org.eclipse.tractusx.ssi.lib.exception.JwtAudienceCheckFailedException;
 import org.eclipse.tractusx.ssi.lib.exception.JwtExpiredException;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtValidator;
 
+/** This is example class to demonstrate how to validate JWT expiry date and audience */
 public class Validation {
+  /**
+   * Validate jwt date.
+   *
+   * @param signedJWT the signed jwt
+   * @param audience the audience
+   * @throws JwtAudienceCheckFailedException the jwt audience check failed exception
+   * @throws JwtExpiredException the jwt expired exception
+   */
   public static void validateJWTDate(SignedJWT signedJWT, String audience)
       throws JwtAudienceCheckFailedException, JwtExpiredException {
     SignedJwtValidator jwtValidator = new SignedJwtValidator();
     jwtValidator.validateDate(signedJWT);
   }
 
+  /**
+   * Validate jwt audiences.
+   *
+   * @param signedJWT the signed jwt
+   * @param audience the audience
+   * @throws JwtAudienceCheckFailedException the jwt audience check failed exception
+   * @throws JwtExpiredException the jwt expired exception
+   */
   public static void validateJWTAudiences(SignedJWT signedJWT, String audience)
       throws JwtAudienceCheckFailedException, JwtExpiredException {
     SignedJwtValidator jwtValidator = new SignedJwtValidator();

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
@@ -31,8 +31,17 @@ import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtVerifier;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
 
+/**
+ * This is example class to demonstrate how verify @{@link SignedJWT} and {@link
+ * VerifiableCredential}
+ */
 public class Verification {
 
+  /**
+   * Verify jwt.
+   *
+   * @param jwt the jwt
+   */
   public static void verifyJWT(SignedJWT jwt) {
     // DID Resolver constructor params
     DidWebParser didParser = new DidWebParser();
@@ -50,6 +59,12 @@ public class Verification {
     }
   }
 
+  /**
+   * Verify ed 21559 ld boolean.
+   *
+   * @param verifiableCredential the verifiable credential
+   * @return the boolean
+   */
   public static boolean verifyED21559LD(VerifiableCredential verifiableCredential) {
     // DID Resolver constructor params
     DidWebParser didParser = new DidWebParser();
@@ -61,6 +76,12 @@ public class Verification {
     return proofValidation.verify(verifiableCredential);
   }
 
+  /**
+   * Verify jwsld boolean.
+   *
+   * @param verifiableCredential the verifiable credential
+   * @return the boolean
+   */
   public static boolean verifyJWSLD(VerifiableCredential verifiableCredential) {
     // DID Resolver constructor params
     DidWebParser didParser = new DidWebParser();

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
@@ -32,8 +32,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
 
 /**
- * This is example class to demonstrate how verify @{@link SignedJWT} and {@link
- * VerifiableCredential}
+ * This is example class to demonstrate how to verify @{@link SignedJWT} and {@link VerifiableCredential}
  */
 public class Verification {
 
@@ -60,7 +59,7 @@ public class Verification {
   }
 
   /**
-   * Verify ed 21559 ld boolean.
+   * Verify ed21559 signed ld.
    *
    * @param verifiableCredential the verifiable credential
    * @return the boolean
@@ -77,7 +76,7 @@ public class Verification {
   }
 
   /**
-   * Verify jwsld boolean.
+   * Verify jws signed ld.
    *
    * @param verifiableCredential the verifiable credential
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/examples/Verification.java
@@ -32,7 +32,8 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
 import org.eclipse.tractusx.ssi.lib.proof.LinkedDataProofValidation;
 
 /**
- * This is example class to demonstrate how to verify @{@link SignedJWT} and {@link VerifiableCredential}
+ * This is example class to demonstrate how to verify @{@link SignedJWT} and {@link
+ * VerifiableCredential}
  */
 public class Verification {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/SsiLibrary.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/SsiLibrary.java
@@ -25,7 +25,7 @@ import java.security.Security;
 import net.i2p.crypto.eddsa.EdDSASecurityProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-/** The type Ssi library. */
+/** The type SSI library. */
 public final class SsiLibrary {
   /** Initialize. */
   public static void initialize() {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/SsiLibrary.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/SsiLibrary.java
@@ -25,7 +25,9 @@ import java.security.Security;
 import net.i2p.crypto.eddsa.EdDSASecurityProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
+/** The type Ssi library. */
 public final class SsiLibrary {
+  /** Initialize. */
   public static void initialize() {
     Security.addProvider(new EdDSASecurityProvider());
     Security.addProvider(new BouncyCastleProvider());

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKey.java
@@ -24,13 +24,36 @@ package org.eclipse.tractusx.ssi.lib.crypt;
 import java.io.IOException;
 import org.eclipse.tractusx.ssi.lib.model.base.EncodeType;
 
+/** The interface Key. */
 public interface IKey {
-  // TODO add docs
+  /**
+   * Gets key length.
+   *
+   * @return the key length
+   */
   int getKeyLength();
 
+  /**
+   * As string for storing string.
+   *
+   * @return the string
+   * @throws IOException the io exception
+   */
   String asStringForStoring() throws IOException;
 
+  /**
+   * As string for exchange string.
+   *
+   * @param encodeType the encode type
+   * @return the string
+   * @throws IOException the io exception
+   */
   String asStringForExchange(EncodeType encodeType) throws IOException;
 
+  /**
+   * As byte byte [ ].
+   *
+   * @return the byte [ ]
+   */
   byte[] asByte();
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKey.java
@@ -34,7 +34,7 @@ public interface IKey {
   int getKeyLength();
 
   /**
-   * As string for storing string.
+   * Convert the key to a string for storing
    *
    * @return the string
    * @throws IOException the io exception
@@ -42,7 +42,7 @@ public interface IKey {
   String asStringForStoring() throws IOException;
 
   /**
-   * As string for exchange string.
+   * Convert the key to a string for exchange.
    *
    * @param encodeType the encode type
    * @return the string
@@ -51,7 +51,7 @@ public interface IKey {
   String asStringForExchange(EncodeType encodeType) throws IOException;
 
   /**
-   * As byte byte [ ].
+   * Convert the key to a byte array.
    *
    * @return the byte [ ]
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
@@ -23,6 +23,14 @@ package org.eclipse.tractusx.ssi.lib.crypt;
 
 import org.eclipse.tractusx.ssi.lib.exception.KeyGenerationException;
 
+/** The interface Key generator. */
 public interface IKeyGenerator {
+
+  /**
+   * Generate key key pair.
+   *
+   * @return the key pair
+   * @throws KeyGenerationException the key generation exception
+   */
   KeyPair generateKey() throws KeyGenerationException;
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
@@ -23,7 +23,7 @@ package org.eclipse.tractusx.ssi.lib.crypt;
 
 import org.eclipse.tractusx.ssi.lib.exception.KeyGenerationException;
 
-/** The interface Key generator. */
+/** The interface KeyGenerator. */
 public interface IKeyGenerator {
 
   /**

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IKeyGenerator.java
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.ssi.lib.exception.KeyGenerationException;
 public interface IKeyGenerator {
 
   /**
-   * Generate key key pair.
+   * Generate key pair.
    *
    * @return the key pair
    * @throws KeyGenerationException the key generation exception

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPrivateKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPrivateKey.java
@@ -21,5 +21,5 @@
 
 package org.eclipse.tractusx.ssi.lib.crypt;
 
-/** The interface Private key. */
+/** The interface private key. */
 public interface IPrivateKey extends IKey {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPrivateKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPrivateKey.java
@@ -21,4 +21,5 @@
 
 package org.eclipse.tractusx.ssi.lib.crypt;
 
+/** The interface Private key. */
 public interface IPrivateKey extends IKey {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPublicKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPublicKey.java
@@ -21,4 +21,5 @@
 
 package org.eclipse.tractusx.ssi.lib.crypt;
 
+/** The interface Public key. */
 public interface IPublicKey extends IKey {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPublicKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/IPublicKey.java
@@ -21,5 +21,5 @@
 
 package org.eclipse.tractusx.ssi.lib.crypt;
 
-/** The interface Public key. */
+/** The interface public key. */
 public interface IPublicKey extends IKey {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/KeyPair.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/KeyPair.java
@@ -24,7 +24,7 @@ package org.eclipse.tractusx.ssi.lib.crypt;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
-/** The type Key pair. */
+/** The type key pair. */
 @RequiredArgsConstructor
 @Data
 public class KeyPair {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/KeyPair.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/KeyPair.java
@@ -24,6 +24,7 @@ package org.eclipse.tractusx.ssi.lib.crypt;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
+/** The type Key pair. */
 @RequiredArgsConstructor
 @Data
 public class KeyPair {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
@@ -28,13 +28,13 @@ import org.eclipse.tractusx.ssi.lib.crypt.IPrivateKey;
 import org.eclipse.tractusx.ssi.lib.crypt.IPublicKey;
 import org.eclipse.tractusx.ssi.lib.crypt.octet.OctetKeyPairFactory;
 
-/** The type Json web key. */
+/** The type JsonWebKey. */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonWebKey {
   private final OctetKeyPair keyPair;
 
   /**
-   * Instantiates a new Json web key.
+   * Instantiates a new JsonWebKey.
    *
    * @param id the id
    * @param publicKey the public key

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
@@ -47,7 +47,7 @@ public class JsonWebKey {
   }
 
   /**
-   * Gets curve.
+   * Gets the curve name of the key pair.
    *
    * @return the curve
    */
@@ -74,7 +74,7 @@ public class JsonWebKey {
   }
 
   /**
-   * Gets x.
+   * Gets the x member contains the x coordinate for the elliptic curve point.
    *
    * @return the x
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
@@ -22,36 +22,62 @@
 package org.eclipse.tractusx.ssi.lib.crypt.jwk;
 
 import com.nimbusds.jose.jwk.OctetKeyPair;
-import java.io.IOException;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.crypt.IPrivateKey;
 import org.eclipse.tractusx.ssi.lib.crypt.IPublicKey;
 import org.eclipse.tractusx.ssi.lib.crypt.octet.OctetKeyPairFactory;
 
+/** The type Json web key. */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonWebKey {
   private final OctetKeyPair keyPair;
 
-  public JsonWebKey(String id, IPublicKey publicKey, IPrivateKey privateKey) throws IOException {
+  /**
+   * Instantiates a new Json web key.
+   *
+   * @param id the id
+   * @param publicKey the public key
+   * @param privateKey the private key
+   */
+  public JsonWebKey(String id, IPublicKey publicKey, IPrivateKey privateKey) {
     OctetKeyPairFactory keyPairFactory = new OctetKeyPairFactory();
     OctetKeyPair keyOctetKeyPair = keyPairFactory.fromKeyPairWithKeyID(id, publicKey, privateKey);
-
     this.keyPair = keyOctetKeyPair;
   }
 
+  /**
+   * Gets curv.
+   *
+   * @return the curv
+   */
   public String getCurv() {
     return keyPair.getCurve().getName();
   }
 
+  /**
+   * Gets key id.
+   *
+   * @return the key id
+   */
   public String getKeyID() {
     return keyPair.getKeyID();
   }
 
+  /**
+   * Gets key type.
+   *
+   * @return the key type
+   */
   public String getKeyType() {
     return this.keyPair.getKeyType().getValue();
   }
 
+  /**
+   * Gets x.
+   *
+   * @return the x
+   */
   public String getX() {
     return this.keyPair.getX().toString();
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/jwk/JsonWebKey.java
@@ -47,9 +47,9 @@ public class JsonWebKey {
   }
 
   /**
-   * Gets curv.
+   * Gets curve.
    *
-   * @return the curv
+   * @return the curve
    */
   public String getCurv() {
     return keyPair.getCurve().getName();

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/octet/OctetKeyPairFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/octet/OctetKeyPairFactory.java
@@ -28,22 +28,45 @@ import java.io.IOException;
 import org.eclipse.tractusx.ssi.lib.crypt.IPrivateKey;
 import org.eclipse.tractusx.ssi.lib.crypt.IPublicKey;
 
+/** The type Octet key pair factory. */
 public class OctetKeyPairFactory {
 
+  /**
+   * Create {@link OctetKeyPair} from {@link IPrivateKey}
+   *
+   * @param privateKey the private key
+   * @return the octet key pair
+   * @throws IOException the io exception
+   */
   public OctetKeyPair fromPrivateKey(IPrivateKey privateKey) throws IOException {
     return new OctetKeyPair.Builder(Curve.Ed25519, new Base64URL(""))
         .d(Base64URL.encode(privateKey.asByte()))
         .build();
   }
 
-  public OctetKeyPair fromKeyPair(IPublicKey publicKey, IPrivateKey privateKey) throws IOException {
+  /**
+   * Create {@link OctetKeyPair} from {@link IPublicKey} and {@link IPrivateKey}
+   *
+   * @param publicKey the public key
+   * @param privateKey the private key
+   * @return the octet key pair
+   */
+  public OctetKeyPair fromKeyPair(IPublicKey publicKey, IPrivateKey privateKey) {
     return new OctetKeyPair.Builder(Curve.Ed25519, Base64URL.encode(publicKey.asByte()))
         .d(Base64URL.encode(privateKey.asByte()))
         .build();
   }
 
+  /**
+   * Create {@link OctetKeyPair} from {@link IPublicKey}, {@link IPrivateKey} and id
+   *
+   * @param keyID the key id
+   * @param publicKey the public key
+   * @param privateKey the private key
+   * @return the octet key pair
+   */
   public OctetKeyPair fromKeyPairWithKeyID(
-      String keyID, IPublicKey publicKey, IPrivateKey privateKey) throws IOException {
+      String keyID, IPublicKey publicKey, IPrivateKey privateKey) {
     return new OctetKeyPair.Builder(Curve.Ed25519, Base64URL.encode(publicKey.asByte()))
         .d(Base64URL.encode(privateKey.asByte()))
         .keyID(keyID)

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559Generator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559Generator.java
@@ -33,6 +33,7 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidePrivateKeyFormat;
 import org.eclipse.tractusx.ssi.lib.exception.InvalidePublicKeyFormat;
 import org.eclipse.tractusx.ssi.lib.exception.KeyGenerationException;
 
+/** X21559 key generator. */
 public class x21559Generator implements IKeyGenerator {
 
   @Override
@@ -59,9 +60,6 @@ public class x21559Generator implements IKeyGenerator {
     } catch (InvalidePublicKeyFormat e) {
       throw new KeyGenerationException(e.getCause());
     }
-
-    KeyPair pair = new KeyPair(x21559PublicKey, x21559PrivateKey);
-
-    return pair;
+    return new KeyPair(x21559PublicKey, x21559PrivateKey);
   }
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PrivateKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PrivateKey.java
@@ -35,10 +35,17 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidePrivateKeyFormat;
 import org.eclipse.tractusx.ssi.lib.model.base.EncodeType;
 import org.eclipse.tractusx.ssi.lib.model.base.MultibaseFactory;
 
+/** The type X21559 private key. */
 public class x21559PrivateKey implements IPrivateKey {
 
   private final @NonNull byte[] key;
 
+  /**
+   * Instantiates a new X 21559 private key.
+   *
+   * @param privateKey the private key
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   */
   public x21559PrivateKey(byte[] privateKey) throws InvalidePrivateKeyFormat {
     if (this.getKeyLength() != privateKey.length) {
       throw new InvalidePrivateKeyFormat(getKeyLength(), privateKey.length);
@@ -46,9 +53,17 @@ public class x21559PrivateKey implements IPrivateKey {
     this.key = privateKey;
   }
 
-  public x21559PrivateKey(String privateKey, boolean PEMFormat)
+  /**
+   * Instantiates a new X 21559 private key.
+   *
+   * @param privateKey the private key
+   * @param pemFormat the pem format
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws IOException the io exception
+   */
+  public x21559PrivateKey(String privateKey, boolean pemFormat)
       throws InvalidePrivateKeyFormat, IOException {
-    if (PEMFormat) {
+    if (pemFormat) {
       StringReader sr = new StringReader(privateKey);
       PemReader reader = new PemReader(sr);
       PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(reader.readPemObject().getContent());
@@ -77,7 +92,7 @@ public class x21559PrivateKey implements IPrivateKey {
   }
 
   @Override
-  public String asStringForExchange(EncodeType encodeType) throws IOException {
+  public String asStringForExchange(EncodeType encodeType) {
 
     return MultibaseFactory.create(encodeType, key).getEncoded();
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PublicKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PublicKey.java
@@ -35,10 +35,17 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidePublicKeyFormat;
 import org.eclipse.tractusx.ssi.lib.model.base.EncodeType;
 import org.eclipse.tractusx.ssi.lib.model.base.MultibaseFactory;
 
+/** The type X 21559 public key. */
 public class x21559PublicKey implements IPublicKey {
 
   private final @NonNull byte[] originalKey;
 
+  /**
+   * Instantiates a new X 21559 public key.
+   *
+   * @param publicKey the public key
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   */
   public x21559PublicKey(byte[] publicKey) throws InvalidePublicKeyFormat {
     if (this.getKeyLength() != publicKey.length) {
       throw new InvalidePublicKeyFormat(getKeyLength(), publicKey.length);
@@ -46,10 +53,18 @@ public class x21559PublicKey implements IPublicKey {
     this.originalKey = publicKey;
   }
 
-  public x21559PublicKey(String publicKey, boolean PEMformat)
+  /**
+   * Instantiates a new X 21559 public key.
+   *
+   * @param publicKey the public key
+   * @param pemFormat the pe mformat
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   * @throws IOException the io exception
+   */
+  public x21559PublicKey(String publicKey, boolean pemFormat)
       throws InvalidePublicKeyFormat, IOException {
 
-    if (PEMformat) {
+    if (pemFormat) {
       StringReader sr = new StringReader(publicKey);
       PemReader reader = new PemReader(sr);
       PemObject pemObject = reader.readPemObject();

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PublicKey.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/crypt/x21559/x21559PublicKey.java
@@ -54,7 +54,7 @@ public class x21559PublicKey implements IPublicKey {
   }
 
   /**
-   * Instantiates a new X 21559 public key.
+   * Instantiates a new X21559 public key.
    *
    * @param publicKey the public key
    * @param pemFormat the pe mformat

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/CompositeDidResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/CompositeDidResolver.java
@@ -32,8 +32,14 @@ import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
  * DID or fails to return a DID document.
  */
 public class CompositeDidResolver implements DidResolver {
+  /** The Did resolvers. */
   DidResolver[] didResolvers;
 
+  /**
+   * Instantiates a new Composite did resolver.
+   *
+   * @param didResolvers the did resolvers
+   */
   public CompositeDidResolver(DidResolver... didResolvers) {
     this.didResolvers = didResolvers;
   }
@@ -66,7 +72,7 @@ public class CompositeDidResolver implements DidResolver {
 
   /**
    * Constructs a new {@code CompositeDidResolver} by appending the {@code toBeAppended} resolver to
-   * the {@target} resolver.
+   * the target {@link DidResolver} resolver.
    *
    * @param target the {@code DidResolver} to append the other to
    * @param toBeAppended the {@code DidResolver} to be appended

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolver.java
@@ -25,13 +25,25 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** The interface Did document resolver. */
 @Deprecated
 /**
  * @deprecated replaced by {@link DidResolver}
  */
 public interface DidDocumentResolver {
 
+  /**
+   * Gets supported method.
+   *
+   * @return the supported method
+   */
   DidMethod getSupportedMethod();
 
+  /**
+   * Resolve did document.
+   *
+   * @param did the did
+   * @return the did document
+   */
   DidDocument resolve(Did did);
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistry.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistry.java
@@ -41,14 +41,14 @@ public interface DidDocumentResolverRegistry {
   DidDocumentResolver get(DidMethod did) throws DidDocumentResolverNotRegisteredException;
 
   /**
-   * Register.
+   * Register a new did document resolver
    *
    * @param resolver the resolver
    */
   void register(DidDocumentResolver resolver);
 
   /**
-   * Unregister.
+   * Unregister a did document resolver
    *
    * @param resolver the resolver
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistry.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistry.java
@@ -25,12 +25,32 @@ import org.eclipse.tractusx.ssi.lib.exception.DidDocumentResolverNotRegisteredEx
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
 /**
+ * The interface Did document resolver registry.
+ *
  * @deprecated replaced by {@link DidResolver}
  */
 public interface DidDocumentResolverRegistry {
+  /**
+   * Get did document resolver.
+   *
+   * @param did the did
+   * @return the did document resolver
+   * @throws DidDocumentResolverNotRegisteredException the did document resolver not registered
+   *     exception
+   */
   DidDocumentResolver get(DidMethod did) throws DidDocumentResolverNotRegisteredException;
 
+  /**
+   * Register.
+   *
+   * @param resolver the resolver
+   */
   void register(DidDocumentResolver resolver);
 
+  /**
+   * Unregister.
+   *
+   * @param resolver the resolver
+   */
   void unregister(DidDocumentResolver resolver);
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistryImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidDocumentResolverRegistryImpl.java
@@ -28,10 +28,13 @@ import org.eclipse.tractusx.ssi.lib.exception.SsiException;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
 /**
+ * The type Did document resolver registry.
+ *
  * @deprecated replaced by {@link DidResolver}
  */
 public class DidDocumentResolverRegistryImpl implements DidDocumentResolverRegistry {
 
+  /** The Resolvers. */
   public final Map<DidMethod, DidDocumentResolver> resolvers = new HashMap<>();
 
   @Override

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
@@ -21,24 +21,50 @@
 
 package org.eclipse.tractusx.ssi.lib.did.resolver;
 
+/** The type Did resolver exception. */
 public class DidResolverException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
+  /** Instantiates a new Did resolver exception. */
   public DidResolverException() {}
 
+  /**
+   * Instantiates a new Did resolver exception.
+   *
+   * @param message the message
+   */
   public DidResolverException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Did resolver exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public DidResolverException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Instantiates a new Did resolver exception.
+   *
+   * @param cause the cause
+   */
   public DidResolverException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Instantiates a new Did resolver exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   * @param enableSuppression the enable suppression
+   * @param writableStackTrace the writable stack trace
+   */
   public DidResolverException(
       String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
@@ -39,7 +39,7 @@ public class DidResolverException extends Exception {
   }
 
   /**
-   * Instantiates a new Did resolver exception.
+   * Instantiates a new Did resolver exception from another exception with a message.
    *
    * @param message the message
    * @param cause the cause
@@ -49,7 +49,7 @@ public class DidResolverException extends Exception {
   }
 
   /**
-   * Instantiates a new Did resolver exception.
+   * Instantiates a new Did resolver exception from another exception.
    *
    * @param cause the cause
    */
@@ -58,7 +58,7 @@ public class DidResolverException extends Exception {
   }
 
   /**
-   * Instantiates a new Did resolver exception.
+   * Instantiates a new Did resolver exception with a message from another exception, allowing for disabling and printing the stack trace.
    *
    * @param message the message
    * @param cause the cause

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidResolverException.java
@@ -58,7 +58,8 @@ public class DidResolverException extends Exception {
   }
 
   /**
-   * Instantiates a new Did resolver exception with a message from another exception, allowing for disabling and printing the stack trace.
+   * Instantiates a new Did resolver exception with a message from another exception, allowing for
+   * disabling and printing the stack trace.
    *
    * @param message the message
    * @param cause the cause

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolver.java
@@ -42,11 +42,27 @@ public class DidUniResolver implements DidResolver {
   private final URI uniResolverEndpoint;
   private static final String uniResolverResolvePath = "./1.0/identifiers/";
 
+  /**
+   * Instantiates a new Did uni resolver.
+   *
+   * @param client the client
+   * @param uniResolverEndpoint the uni resolver endpoint
+   * @throws MalformedURLException the malformed url exception
+   * @throws URISyntaxException the uri syntax exception
+   */
   public DidUniResolver(HttpClient client, String uniResolverEndpoint)
       throws MalformedURLException, URISyntaxException {
     this(client, URI.create(uniResolverEndpoint));
   }
 
+  /**
+   * Instantiates a new Did uni resolver.
+   *
+   * @param client the client
+   * @param uniResolverEndpoint the uni resolver endpoint
+   * @throws MalformedURLException the malformed url exception
+   * @throws URISyntaxException the uri syntax exception
+   */
   public DidUniResolver(HttpClient client, URI uniResolverEndpoint)
       throws MalformedURLException, URISyntaxException {
     this.client = client;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebDocumentResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebDocumentResolver.java
@@ -39,6 +39,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** The type Did web document resolver. */
 @RequiredArgsConstructor
 @Deprecated
 /**

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebFactory.java
@@ -26,12 +26,26 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethodIdentifier;
 
+/** The type Did web factory. */
 public class DidWebFactory {
 
+  /**
+   * From hostname did.
+   *
+   * @param hostName the host name
+   * @return the did
+   */
   public static Did fromHostname(String hostName) {
     return fromHostnameAndPath(hostName, "");
   }
 
+  /**
+   * From hostname and path did.
+   *
+   * @param hostName the host name
+   * @param path the path
+   * @return the did
+   */
   public static Did fromHostnameAndPath(String hostName, String path) {
     Objects.requireNonNull(hostName, "Hostname must not be null");
     Objects.requireNonNull(path, "Path must not be null");

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolver.java
@@ -36,6 +36,7 @@ import org.eclipse.tractusx.ssi.lib.did.web.util.DidWebParser;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 
+/** The type Did web resolver. */
 @RequiredArgsConstructor
 public class DidWebResolver implements DidResolver {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/Constants.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/Constants.java
@@ -23,6 +23,8 @@ package org.eclipse.tractusx.ssi.lib.did.web.util;
 
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** The type Constants. */
 public class Constants {
+  /** The constant DID_WEB_METHOD. */
   public static final DidMethod DID_WEB_METHOD = new DidMethod("web");
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/DidWebParser.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/DidWebParser.java
@@ -28,16 +28,30 @@ import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.exception.DidParseException;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 
+/** The type Did web parser. */
 @RequiredArgsConstructor
 public class DidWebParser {
 
   private static final String WELL_KNOWN_DID_JSON = "/.well-known/did.json";
   private static final String PATH_DID_JSON = "/did.json";
 
+  /**
+   * Parse uri.
+   *
+   * @param did the did
+   * @return the uri
+   */
   public URI parse(Did did) {
     return parse(did, true);
   }
 
+  /**
+   * Parse uri.
+   *
+   * @param did the did
+   * @param enforceHttps the enforce https
+   * @return the uri
+   */
   @SneakyThrows({URISyntaxException.class})
   public URI parse(Did did, boolean enforceHttps) {
     if (!did.getMethod().equals(Constants.DID_WEB_METHOD)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/Ed25519PublicKeyParser.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/util/Ed25519PublicKeyParser.java
@@ -27,12 +27,14 @@ import org.bouncycastle.util.io.pem.PemReader;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 import org.eclipse.tractusx.ssi.lib.model.base.MultibaseFactory;
 
+/** The type Ed 25519 public key parser. */
 public class Ed25519PublicKeyParser {
 
   /**
    * Parses public key in format -----BEGIN PUBLIC KEY-----
    * MCowBQYDK2VwAyEABqAmUe/amV/nAVUt01XyrLpmQLOyLqF6LnAkH4QdyqI= -----END PUBLIC KEY-----
    *
+   * @param publicKey the public key
    * @return public key as multibase string
    */
   public static MultibaseString parsePublicKey(String publicKey) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidDocumentResolverNotRegisteredException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidDocumentResolverNotRegisteredException.java
@@ -23,8 +23,14 @@ package org.eclipse.tractusx.ssi.lib.exception;
 
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** The type Did document resolver not registered exception. */
 public class DidDocumentResolverNotRegisteredException extends Exception {
 
+  /**
+   * Instantiates a new Did document resolver not registered exception.
+   *
+   * @param didMethod the did method
+   */
   public DidDocumentResolverNotRegisteredException(DidMethod didMethod) {
     super(String.format("No DID document resolver registered for DID method '%s'", didMethod));
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidParseException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidParseException.java
@@ -21,11 +21,23 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Did parse exception. */
 public class DidParseException extends SsiException {
+  /**
+   * Instantiates a new Did parse exception.
+   *
+   * @param message the message
+   */
   public DidParseException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Did parse exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public DidParseException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidWebException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/DidWebException.java
@@ -21,22 +21,48 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Did web exception. */
 public class DidWebException extends RuntimeException {
 
+  /** Instantiates a new Did web exception. */
   public DidWebException() {}
 
+  /**
+   * Instantiates a new Did web exception.
+   *
+   * @param message the message
+   */
   public DidWebException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Did web exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public DidWebException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Instantiates a new Did web exception.
+   *
+   * @param cause the cause
+   */
   public DidWebException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Instantiates a new Did web exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   * @param enableSuppression the enable suppression
+   * @param writableStackTrace the writable stack trace
+   */
   public DidWebException(
       String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidJsonLdException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidJsonLdException.java
@@ -21,15 +21,32 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Invalid json ld exception. */
 public class InvalidJsonLdException extends Exception {
+  /**
+   * Instantiates a new Invalid json ld exception.
+   *
+   * @param message the message
+   */
   public InvalidJsonLdException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Invalid json ld exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public InvalidJsonLdException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Instantiates a new Invalid json ld exception.
+   *
+   * @param cause the cause
+   */
   public InvalidJsonLdException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidePrivateKeyFormat.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidePrivateKeyFormat.java
@@ -21,7 +21,14 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Invalide private key format. */
 public class InvalidePrivateKeyFormat extends Exception {
+  /**
+   * Instantiates a new Invalide private key format.
+   *
+   * @param correctLength the correct length
+   * @param providedLength the provided length
+   */
   public InvalidePrivateKeyFormat(int correctLength, int providedLength) {
     super(
         String.format(
@@ -29,5 +36,10 @@ public class InvalidePrivateKeyFormat extends Exception {
             correctLength, providedLength));
   }
 
+  /**
+   * Instantiates a new Invalide private key format.
+   *
+   * @param cause the cause
+   */
   public InvalidePrivateKeyFormat(Throwable cause) {}
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidePublicKeyFormat.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/InvalidePublicKeyFormat.java
@@ -21,8 +21,15 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Invalide public key format. */
 public class InvalidePublicKeyFormat extends Exception {
 
+  /**
+   * Instantiates a new Invalide public key format.
+   *
+   * @param correctLength the correct length
+   * @param providedLength the provided length
+   */
   public InvalidePublicKeyFormat(int correctLength, int providedLength) {
     super(
         String.format(
@@ -30,5 +37,10 @@ public class InvalidePublicKeyFormat extends Exception {
             correctLength, providedLength));
   }
 
+  /**
+   * Instantiates a new Invalide public key format.
+   *
+   * @param cause the cause
+   */
   public InvalidePublicKeyFormat(Throwable cause) {}
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtAudienceCheckFailedException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtAudienceCheckFailedException.java
@@ -23,7 +23,14 @@ package org.eclipse.tractusx.ssi.lib.exception;
 
 import java.util.List;
 
+/** The type Jwt audience check failed exception. */
 public class JwtAudienceCheckFailedException extends JwtException {
+  /**
+   * Instantiates a new Jwt audience check failed exception.
+   *
+   * @param expectedAudience the expected audience
+   * @param actualAudience the actual audience
+   */
   public JwtAudienceCheckFailedException(String expectedAudience, List<String> actualAudience) {
     super(
         "JWT audience check failed. Expected audience: "

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtException.java
@@ -21,16 +21,33 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Jwt exception. */
 public class JwtException extends Exception {
 
+  /**
+   * Instantiates a new Jwt exception.
+   *
+   * @param message the message
+   */
   public JwtException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Jwt exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public JwtException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Instantiates a new Jwt exception.
+   *
+   * @param cause the cause
+   */
   public JwtException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtExpiredException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtExpiredException.java
@@ -23,8 +23,14 @@ package org.eclipse.tractusx.ssi.lib.exception;
 
 import java.util.Date;
 
+/** The type Jwt expired exception. */
 public class JwtExpiredException extends JwtException {
 
+  /**
+   * Instantiates a new Jwt expired exception.
+   *
+   * @param expiryDate the expiry date
+   */
   public JwtExpiredException(Date expiryDate) {
     super("JWT expired at " + expiryDate);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtSignatureCheckFailedException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtSignatureCheckFailedException.java
@@ -25,11 +25,22 @@ import java.net.URI;
 import lombok.Getter;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 
+/** The type Jwt signature check failed exception. */
 @Getter
 public class JwtSignatureCheckFailedException extends JwtException {
+
+  /** Issuer did */
   private final Did issuerDid;
+
+  /** Verification key */
   private final URI verificationKey;
 
+  /**
+   * Instantiates a new Jwt signature check failed exception.
+   *
+   * @param issuerDid the issuer did
+   * @param verificationKey the verification key
+   */
   public JwtSignatureCheckFailedException(Did issuerDid, URI verificationKey) {
     super(
         "JWT signature check failed for issuer "

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtSignatureVerificationKeyNotFoundException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/JwtSignatureVerificationKeyNotFoundException.java
@@ -21,4 +21,5 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Jwt signature verification key not found exception. */
 public class JwtSignatureVerificationKeyNotFoundException {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/KeyGenerationException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/KeyGenerationException.java
@@ -21,7 +21,13 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Key generation exception. */
 public class KeyGenerationException extends Exception {
 
+  /**
+   * Instantiates a new Key generation exception.
+   *
+   * @param cause the cause
+   */
   public KeyGenerationException(Throwable cause) {}
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/NoVerificationKeyFoundExcpetion.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/NoVerificationKeyFoundExcpetion.java
@@ -24,6 +24,11 @@ package org.eclipse.tractusx.ssi.lib.exception;
 /** NoVerificationKeyFoundExcpetion */
 public class NoVerificationKeyFoundExcpetion extends Exception {
 
+  /**
+   * Instantiates a new No verification key found excpetion.
+   *
+   * @param message the message
+   */
   public NoVerificationKeyFoundExcpetion(String message) {
     super(message);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/SsiException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/SsiException.java
@@ -21,22 +21,48 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Ssi exception. */
 public class SsiException extends RuntimeException {
 
+  /** Instantiates a new Ssi exception. */
   public SsiException() {}
 
+  /**
+   * Instantiates a new Ssi exception.
+   *
+   * @param message the message
+   */
   public SsiException(String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Ssi exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public SsiException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  /**
+   * Instantiates a new Ssi exception.
+   *
+   * @param cause the cause
+   */
   public SsiException(Throwable cause) {
     super(cause);
   }
 
+  /**
+   * Instantiates a new Ssi exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   * @param enableSuppression the enable suppression
+   * @param writableStackTrace the writable stack trace
+   */
   public SsiException(
       String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedDidMethodException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedDidMethodException.java
@@ -23,7 +23,14 @@ package org.eclipse.tractusx.ssi.lib.exception;
 
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 
+/** The type Unsupported did method exception. */
 public class UnsupportedDidMethodException extends Exception {
+  /**
+   * Instantiates a new Unsupported did method exception.
+   *
+   * @param did the did
+   * @param contextMessage the context message
+   */
   public UnsupportedDidMethodException(Did did, String contextMessage) {
     super(
         String.format(

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedSignatureTypeException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedSignatureTypeException.java
@@ -21,7 +21,13 @@
 
 package org.eclipse.tractusx.ssi.lib.exception;
 
+/** The type Unsupported signature type exception. */
 public class UnsupportedSignatureTypeException extends Exception {
+  /**
+   * Instantiates a new Unsupported signature type exception.
+   *
+   * @param signatureType the signature type
+   */
   public UnsupportedSignatureTypeException(String signatureType) {
     super("Unsupported signature type: " + signatureType);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedVerificationMethodException.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/exception/UnsupportedVerificationMethodException.java
@@ -24,8 +24,15 @@ package org.eclipse.tractusx.ssi.lib.exception;
 import lombok.Getter;
 import org.eclipse.tractusx.ssi.lib.model.did.VerificationMethod;
 
+/** The type Unsupported verification method exception. */
 public class UnsupportedVerificationMethodException extends RuntimeException {
 
+  /**
+   * Instantiates a new Unsupported verification method exception.
+   *
+   * @param method the method
+   * @param message the message
+   */
   public UnsupportedVerificationMethodException(VerificationMethod method, String message) {
     super(
         String.format(
@@ -33,5 +40,6 @@ public class UnsupportedVerificationMethodException extends RuntimeException {
     this.method = method;
   }
 
+  /** The verification method */
   @Getter private final VerificationMethod method;
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
@@ -50,6 +50,11 @@ public class SignedJwtFactory {
 
   private final OctetKeyPairFactory octetKeyPairFactory;
 
+  /**
+   * Instantiates a new Signed jwt factory.
+   *
+   * @param octetKeyPairFactory the octet key pair factory
+   */
   public SignedJwtFactory(OctetKeyPairFactory octetKeyPairFactory) {
     this.octetKeyPairFactory = Objects.requireNonNull(octetKeyPairFactory);
   }
@@ -59,7 +64,10 @@ public class SignedJwtFactory {
    * all private key types are possible, in the context of Distributed Identity using an Elliptic
    * Curve key ({@code P-256}) is advisable.
    *
+   * @param didIssuer the did issuer
    * @param audience the value of the token audience claim, e.g. the IDS Webhook address.
+   * @param serializedPresentation the serialized presentation
+   * @param privateKey the private key
    * @return a {@code SignedJWT} that is signed with the private key and contains all claims listed.
    */
   @SneakyThrows

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtValidator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtValidator.java
@@ -28,8 +28,14 @@ import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.exception.JwtAudienceCheckFailedException;
 import org.eclipse.tractusx.ssi.lib.exception.JwtExpiredException;
 
+/** The type Signed jwt validator. */
 public class SignedJwtValidator {
 
+  /**
+   * Validate date.
+   *
+   * @param jwt the jwt
+   */
   @SneakyThrows
   public void validateDate(SignedJWT jwt) {
     Date expiryDate = jwt.getJWTClaimsSet().getExpirationTime();
@@ -39,6 +45,12 @@ public class SignedJwtValidator {
     }
   }
 
+  /**
+   * Validate audiences.
+   *
+   * @param jwt the jwt
+   * @param expectedAudience the expected audience
+   */
   @SneakyThrows
   public void validateAudiences(SignedJWT jwt, String expectedAudience) {
     List<String> audiences = jwt.getJWTClaimsSet().getAudience();

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
@@ -60,6 +60,9 @@ public class SignedJwtVerifier {
    *
    * @param jwt a {@link SignedJWT} that was sent by the claiming party.
    * @return true if verified, false otherwise
+   * @throws JwtException the jwt exception
+   * @throws DidDocumentResolverNotRegisteredException the did document resolver not registered
+   *     exception
    */
   @SneakyThrows({JOSEException.class, DidResolverException.class})
   public boolean verify(SignedJWT jwt)

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SigningMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SigningMethod.java
@@ -21,6 +21,8 @@
 
 package org.eclipse.tractusx.ssi.lib.jwt;
 
+/** The type Signing method. */
 public class SigningMethod {
+  /** The constant SIGNING_METHOD_ES256. */
   public static final String SIGNING_METHOD_ES256 = "ES256";
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/JsonLdObject.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/JsonLdObject.java
@@ -35,13 +35,22 @@ import lombok.Getter;
 import lombok.ToString;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Json ld object. */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class JsonLdObject extends HashMap<String, Object> {
 
+  /** The constant CONTEXT. */
   public static final String CONTEXT = "@context";
+
+  /** The {@link DocumentLoader} */
   @ToString.Exclude @Getter private DocumentLoader documentLoader;
 
+  /**
+   * Instantiates a new Json ld object.
+   *
+   * @param json the json
+   */
   public JsonLdObject(Map<String, Object> json) {
     super(json);
 
@@ -63,6 +72,11 @@ public abstract class JsonLdObject extends HashMap<String, Object> {
     }
   }
 
+  /**
+   * Gets context.
+   *
+   * @return the context
+   */
   public List<URI> getContext() {
     final Object context = this.get(CONTEXT);
     if (context instanceof String || context instanceof URI) {
@@ -88,14 +102,29 @@ public abstract class JsonLdObject extends HashMap<String, Object> {
     }
   }
 
+  /**
+   * To json string.
+   *
+   * @return the string
+   */
   public String toJson() {
     return SerializeUtil.toJson(this);
   }
 
+  /**
+   * To pretty json string.
+   *
+   * @return the string
+   */
   public String toPrettyJson() {
     return SerializeUtil.toPrettyJson(this);
   }
 
+  /**
+   * To json object json object.
+   *
+   * @return the json object
+   */
   public synchronized JsonObject toJsonObject() {
     return Json.createObjectBuilder(this).build();
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
@@ -26,14 +26,14 @@ import lombok.NonNull;
 /** The interface Multibase string. */
 public interface MultibaseString {
   /**
-   * Get decoded byte [ ].
+   *  Get as byte array.
    *
    * @return the byte [ ]
    */
   byte[] getDecoded();
 
   /**
-   * Gets encoded.
+   *  Gets as string.
    *
    * @return the encoded
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
@@ -23,9 +23,20 @@ package org.eclipse.tractusx.ssi.lib.model;
 
 import lombok.NonNull;
 
+/** The interface Multibase string. */
 public interface MultibaseString {
+  /**
+   * Get decoded byte [ ].
+   *
+   * @return the byte [ ]
+   */
   byte[] getDecoded();
 
+  /**
+   * Gets encoded.
+   *
+   * @return the encoded
+   */
   @NonNull
   String getEncoded();
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/MultibaseString.java
@@ -26,14 +26,14 @@ import lombok.NonNull;
 /** The interface Multibase string. */
 public interface MultibaseString {
   /**
-   *  Get as byte array.
+   * Get as byte array.
    *
    * @return the byte [ ]
    */
   byte[] getDecoded();
 
   /**
-   *  Gets as string.
+   * Gets as string.
    *
    * @return the encoded
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/RemoteDocumentLoader.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/RemoteDocumentLoader.java
@@ -41,6 +41,9 @@ import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * The type Remote document loader.
+ */
 public class RemoteDocumentLoader implements DocumentLoader {
 
   private static DocumentLoader DEFAULT_HTTP_LOADER;
@@ -62,12 +65,20 @@ public class RemoteDocumentLoader implements DocumentLoader {
   @Getter @Setter private List<URI> httpsContexts = new ArrayList<URI>();
   @Getter @Setter private List<URI> fileContexts = new ArrayList<URI>();
 
+  /**
+   * The constant DOCUMENT_LOADER.
+   */
   public static final RemoteDocumentLoader DOCUMENT_LOADER;
 
   static {
     DOCUMENT_LOADER = new RemoteDocumentLoader();
   }
 
+  /**
+   * Gets default http loader.
+   *
+   * @return the default http loader
+   */
   public static DocumentLoader getDefaultHttpLoader() {
     if (DEFAULT_HTTP_LOADER == null) {
       DEFAULT_HTTP_LOADER = new HttpLoader(DefaultHttpClient.defaultInstance());
@@ -75,6 +86,11 @@ public class RemoteDocumentLoader implements DocumentLoader {
     return DEFAULT_HTTP_LOADER;
   }
 
+  /**
+   * Gets default file loader.
+   *
+   * @return the default file loader
+   */
   public static DocumentLoader getDefaultFileLoader() {
     if (DEFAULT_FILE_LOADER == null) {
       DEFAULT_FILE_LOADER = new FileLoader();
@@ -82,16 +98,31 @@ public class RemoteDocumentLoader implements DocumentLoader {
     return DEFAULT_FILE_LOADER;
   }
 
+  /**
+   * Sets default http loader.
+   *
+   * @param defaultHttpLoader the default http loader
+   */
   public static void setDefaultHttpLoader(DocumentLoader defaultHttpLoader) {
     DEFAULT_HTTP_LOADER = defaultHttpLoader;
   }
 
+  /**
+   * Sets default file loader.
+   *
+   * @param defaultFileLoader the default file loader
+   */
   public static void setDefaultFileLoader(DocumentLoader defaultFileLoader) {
     DEFAULT_FILE_LOADER = defaultFileLoader;
   }
 
   private RemoteDocumentLoader() {}
 
+  /**
+   * Gets instance.
+   *
+   * @return the instance
+   */
   public static synchronized RemoteDocumentLoader getInstance() {
     return DOCUMENT_LOADER;
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/RemoteDocumentLoader.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/RemoteDocumentLoader.java
@@ -41,9 +41,7 @@ import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.Setter;
 
-/**
- * The type Remote document loader.
- */
+/** The type Remote document loader. */
 public class RemoteDocumentLoader implements DocumentLoader {
 
   private static DocumentLoader DEFAULT_HTTP_LOADER;
@@ -65,9 +63,7 @@ public class RemoteDocumentLoader implements DocumentLoader {
   @Getter @Setter private List<URI> httpsContexts = new ArrayList<URI>();
   @Getter @Setter private List<URI> fileContexts = new ArrayList<URI>();
 
-  /**
-   * The constant DOCUMENT_LOADER.
-   */
+  /** The constant DOCUMENT_LOADER. */
   public static final RemoteDocumentLoader DOCUMENT_LOADER;
 
   static {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Bitcoin.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Bitcoin.java
@@ -28,16 +28,29 @@ import lombok.NonNull;
 import lombok.Value;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Base 58 bitcoin. */
 @Value
 @EqualsAndHashCode
 public class Base58Bitcoin implements MultibaseString {
 
+  /**
+   * Can decode boolean.
+   *
+   * @param encoded the encoded
+   * @return the boolean
+   */
   public static boolean canDecode(String encoded) {
     Objects.requireNonNull(encoded, "encoded must not be null");
 
     return Multibase.encoding(encoded).equals(Multibase.Base.Base58BTC);
   }
 
+  /**
+   * Create base 58 bitcoin.
+   *
+   * @param decoded the decoded
+   * @return the base 58 bitcoin
+   */
   public static Base58Bitcoin create(byte[] decoded) {
 
     final String encoded = Multibase.encode(Multibase.Base.Base58BTC, decoded);
@@ -45,6 +58,12 @@ public class Base58Bitcoin implements MultibaseString {
     return new Base58Bitcoin(decoded, encoded);
   }
 
+  /**
+   * Create base 58 bitcoin.
+   *
+   * @param encoded the encoded
+   * @return the base 58 bitcoin
+   */
   public static Base58Bitcoin create(String encoded) {
 
     if (!canDecode(encoded)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Bitcoin.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Bitcoin.java
@@ -34,9 +34,9 @@ import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 public class Base58Bitcoin implements MultibaseString {
 
   /**
-   * Can decode boolean.
+   * Checks if a string can be decoded.
    *
-   * @param encoded the encoded
+   * @param encoded the encoded string
    * @return the boolean
    */
   public static boolean canDecode(String encoded) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Flickr.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Flickr.java
@@ -33,7 +33,7 @@ import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 public class Base58Flickr implements MultibaseString {
 
   /**
-   * Can decode boolean.
+   * Check if it can decode a string.
    *
    * @param encoded the encoded
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Flickr.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base58Flickr.java
@@ -27,14 +27,27 @@ import lombok.NonNull;
 import lombok.Value;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Base 58 flickr. */
 @Value
 @EqualsAndHashCode
 public class Base58Flickr implements MultibaseString {
 
+  /**
+   * Can decode boolean.
+   *
+   * @param encoded the encoded
+   * @return the boolean
+   */
   public static boolean canDecode(String encoded) {
     return Multibase.encoding(encoded).equals(Multibase.Base.Base58Flickr);
   }
 
+  /**
+   * Create base 58 flickr.
+   *
+   * @param encoded the encoded
+   * @return the base 58 flickr
+   */
   public static Base58Flickr create(String encoded) {
 
     if (!canDecode(encoded)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
@@ -27,19 +27,38 @@ import lombok.NonNull;
 import lombok.Value;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Base 64. */
 @Value
 @EqualsAndHashCode
 public class Base64 implements MultibaseString {
 
+  /**
+   * Can decode boolean.
+   *
+   * @param encoded the encoded
+   * @return the boolean
+   */
   public static boolean canDecode(String encoded) {
     return Multibase.encoding(encoded).equals(Multibase.Base.Base64);
   }
 
+  /**
+   * Create base 64.
+   *
+   * @param decoded the decoded
+   * @return the base 64
+   */
   public static Base64 create(byte[] decoded) {
     final String encoded = Multibase.encode(Multibase.Base.Base64, decoded);
     return new Base64(decoded, encoded);
   }
 
+  /**
+   * Create base 64.
+   *
+   * @param encoded the encoded
+   * @return the base 64
+   */
   public static Base64 create(String encoded) {
 
     if (!canDecode(encoded)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
@@ -27,7 +27,7 @@ import lombok.NonNull;
 import lombok.Value;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
-/** The type Base 64. */
+/** The type Base64. */
 @Value
 @EqualsAndHashCode
 public class Base64 implements MultibaseString {
@@ -35,7 +35,7 @@ public class Base64 implements MultibaseString {
   /**
    * Check if it can decode a string.
    *
-   * @param encoded the encoded
+   * @param encoded the encoded string
    * @return the boolean
    */
   public static boolean canDecode(String encoded) {
@@ -43,10 +43,10 @@ public class Base64 implements MultibaseString {
   }
 
   /**
-   * Create base 64.
+   * Create Base64.
    *
    * @param decoded the decoded
-   * @return the base 64
+   * @return the Base64
    */
   public static Base64 create(byte[] decoded) {
     final String encoded = Multibase.encode(Multibase.Base.Base64, decoded);
@@ -54,10 +54,10 @@ public class Base64 implements MultibaseString {
   }
 
   /**
-   * Create base 64.
+   * Create Base64.
    *
    * @param encoded the encoded
-   * @return the base 64
+   * @return the Base64
    */
   public static Base64 create(String encoded) {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64.java
@@ -33,7 +33,7 @@ import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 public class Base64 implements MultibaseString {
 
   /**
-   * Can decode boolean.
+   * Check if it can decode a string.
    *
    * @param encoded the encoded
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64WithPadding.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64WithPadding.java
@@ -27,19 +27,38 @@ import lombok.NonNull;
 import lombok.Value;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Base 64 with padding. */
 @Value
 @EqualsAndHashCode
 public class Base64WithPadding implements MultibaseString {
 
+  /**
+   * Can decode boolean.
+   *
+   * @param encoded the encoded
+   * @return the boolean
+   */
   public static boolean canDecode(String encoded) {
     return Multibase.encoding(encoded).equals(Multibase.Base.Base64Pad);
   }
 
+  /**
+   * Create base 64 with padding.
+   *
+   * @param decoded the decoded
+   * @return the base 64 with padding
+   */
   public static Base64WithPadding create(byte[] decoded) {
     final String encoded = Multibase.encode(Multibase.Base.Base64Pad, decoded);
     return new Base64WithPadding(decoded, encoded);
   }
 
+  /**
+   * Create base 64 with padding.
+   *
+   * @param encoded the encoded
+   * @return the base 64 with padding
+   */
   public static Base64WithPadding create(String encoded) {
 
     if (!canDecode(encoded)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64WithPadding.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/Base64WithPadding.java
@@ -33,9 +33,9 @@ import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 public class Base64WithPadding implements MultibaseString {
 
   /**
-   * Can decode boolean.
+   * Check if a string can be decoded.
    *
-   * @param encoded the encoded
+   * @param encoded the encoded string
    * @return the boolean
    */
   public static boolean canDecode(String encoded) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/EncodeType.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/EncodeType.java
@@ -21,7 +21,10 @@
 
 package org.eclipse.tractusx.ssi.lib.model.base;
 
+/** The enum Encode type. */
 public enum EncodeType {
+  /** Base 64 encode type. */
   Base64,
+  /** Base 58 encode type. */
   Base58,
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/MultibaseFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/base/MultibaseFactory.java
@@ -23,8 +23,16 @@ package org.eclipse.tractusx.ssi.lib.model.base;
 
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Multibase factory. */
 public class MultibaseFactory {
 
+  /**
+   * Create multibase string.
+   *
+   * @param encodeType the encode type
+   * @param decoded the decoded
+   * @return the multibase string
+   */
   public static MultibaseString create(EncodeType encodeType, byte[] decoded) {
     if (encodeType == EncodeType.Base58) {
       return Base58Bitcoin.create(decoded);
@@ -33,10 +41,22 @@ public class MultibaseFactory {
     }
   }
 
+  /**
+   * Create multibase string.
+   *
+   * @param decoded the decoded
+   * @return the multibase string
+   */
   public static MultibaseString create(byte[] decoded) {
     return Base58Bitcoin.create(decoded);
   }
 
+  /**
+   * Create multibase string.
+   *
+   * @param encoded the encoded
+   * @return the multibase string
+   */
   public static MultibaseString create(String encoded) {
 
     if (Base58Bitcoin.canDecode(encoded)) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
@@ -72,7 +72,7 @@ public class Did {
   }
 
   /**
-   * To uri uri.
+   * To uri.
    *
    * @return the uri
    */

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
@@ -27,28 +27,55 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
+/** The type Did. */
 @EqualsAndHashCode
 public class Did {
 
+  /** The Method. */
   @EqualsAndHashCode.Include @Setter @Getter @NonNull DidMethod method;
+  /** The Method identifier. */
   @EqualsAndHashCode.Include @Setter @Getter @NonNull DidMethodIdentifier methodIdentifier;
+  /** The Fragment. */
   @EqualsAndHashCode.Include @Setter @Getter String fragment;
 
+  /**
+   * Instantiates a new Did.
+   *
+   * @param method the method
+   * @param didMethodIdentifier the did method identifier
+   * @param fragment the fragment
+   */
   public Did(DidMethod method, DidMethodIdentifier didMethodIdentifier, String fragment) {
     this.method = method;
     this.methodIdentifier = didMethodIdentifier;
     this.fragment = fragment;
   }
 
+  /**
+   * Instantiates a new Did.
+   *
+   * @param method the method
+   * @param didMethodIdentifier the did method identifier
+   */
   public Did(DidMethod method, DidMethodIdentifier didMethodIdentifier) {
     new Did(method, didMethodIdentifier, null);
   }
 
+  /**
+   * Exclude fragment did.
+   *
+   * @return the did
+   */
   public Did excludeFragment() {
     Did newDid = new Did(method, methodIdentifier, null);
     return newDid;
   }
 
+  /**
+   * To uri uri.
+   *
+   * @return the uri
+   */
   public URI toUri() {
     return URI.create(toString());
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocument.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocument.java
@@ -30,16 +30,25 @@ import lombok.ToString;
 import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
-// spec https://www.w3.org/TR/did-core/
+/** The type Did document. Spec: <a href="https://www.w3.org/TR/did-core/">...</a> */
 @ToString
 public class DidDocument extends JsonLdObject {
 
+  /** The constant DEFAULT_CONTEXT. */
   public static final String DEFAULT_CONTEXT = "https://www.w3.org/ns/did/v1";
+  /** The constant ID. */
   public static final String ID = "id";
+  /** The constant VERIFICATION_METHOD. */
   public static final String VERIFICATION_METHOD = "verificationMethod";
 
+  /** The constant AUTHENTICATION. */
   public static final String AUTHENTICATION = "authentication";
 
+  /**
+   * Instantiates a new Did document.
+   *
+   * @param json the json
+   */
   public DidDocument(Map<String, Object> json) {
     super(json);
 
@@ -54,10 +63,20 @@ public class DidDocument extends JsonLdObject {
     }
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   public URI getId() {
     return SerializeUtil.asURI(get(ID));
   }
 
+  /**
+   * Gets verification methods.
+   *
+   * @return the verification methods
+   */
   public List<VerificationMethod> getVerificationMethods() {
 
     List<VerificationMethod> result = new ArrayList<>();
@@ -74,6 +93,12 @@ public class DidDocument extends JsonLdObject {
     return result;
   }
 
+  /**
+   * From json did document.
+   *
+   * @param json the json
+   * @return the did document
+   */
   public static DidDocument fromJson(String json) {
     var map = SerializeUtil.fromJson(json);
     return new DidDocument(map);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentBuilder.java
@@ -36,7 +36,7 @@ public class DidDocumentBuilder {
   /**
    * Id did document builder.
    *
-   * @param id the id
+   * @param id the document id
    * @return the did document builder
    */
   public DidDocumentBuilder id(URI id) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentBuilder.java
@@ -27,26 +27,50 @@ import java.util.List;
 import java.util.Map;
 import lombok.NoArgsConstructor;
 
+/** The type Did document builder. */
 @NoArgsConstructor
 public class DidDocumentBuilder {
   private URI id;
   private final List<VerificationMethod> verificationMethods = new ArrayList<>();
 
+  /**
+   * Id did document builder.
+   *
+   * @param id the id
+   * @return the did document builder
+   */
   public DidDocumentBuilder id(URI id) {
     this.id = id;
     return this;
   }
 
+  /**
+   * Verification methods did document builder.
+   *
+   * @param verificationMethods the verification methods
+   * @return the did document builder
+   */
   public DidDocumentBuilder verificationMethods(List<VerificationMethod> verificationMethods) {
     this.verificationMethods.addAll(verificationMethods);
     return this;
   }
 
+  /**
+   * Verification method did document builder.
+   *
+   * @param verificationMethod the verification method
+   * @return the did document builder
+   */
   public DidDocumentBuilder verificationMethod(VerificationMethod verificationMethod) {
     this.verificationMethods.add(verificationMethod);
     return this;
   }
 
+  /**
+   * Build did document.
+   *
+   * @return the did document
+   */
   public DidDocument build() {
     return new DidDocument(
         Map.of(

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidMethod.java
@@ -25,11 +25,17 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 
+/** The type Did method. */
 @Value
 @EqualsAndHashCode
 public class DidMethod {
   @EqualsAndHashCode.Include @NonNull String value;
 
+  /**
+   * Instantiates a new Did method.
+   *
+   * @param val the val
+   */
   public DidMethod(String val) {
     if (val.isEmpty()) {
       throw new IllegalArgumentException("Empty value not allowed");

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidMethodIdentifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidMethodIdentifier.java
@@ -25,11 +25,17 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 
+/** The type Did method identifier. */
 @Value
 @EqualsAndHashCode
 public class DidMethodIdentifier {
   @NonNull @EqualsAndHashCode.Include String value;
 
+  /**
+   * Instantiates a new Did method identifier.
+   *
+   * @param val the val
+   */
   public DidMethodIdentifier(String val) {
     if (val.isEmpty()) {
       throw new IllegalArgumentException("Empty value not allowed");

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidParser.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/DidParser.java
@@ -28,8 +28,15 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.eclipse.tractusx.ssi.lib.exception.DidParseException;
 
+/** The type Did parser. */
 public class DidParser {
 
+  /**
+   * Parse did.
+   *
+   * @param uri the uri
+   * @return the did
+   */
   public static Did parse(URI uri) {
     Objects.requireNonNull(uri);
 
@@ -58,6 +65,12 @@ public class DidParser {
         fragment);
   }
 
+  /**
+   * Parse did.
+   *
+   * @param did the did
+   * @return the did
+   */
   public static Did parse(String did) {
     Objects.requireNonNull(did);
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
@@ -28,16 +28,30 @@ import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 import org.eclipse.tractusx.ssi.lib.model.base.MultibaseFactory;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Ed 25519 verification method. */
 @ToString
 public class Ed25519VerificationMethod extends VerificationMethod {
+  /** The constant DEFAULT_TYPE. */
   public static final String DEFAULT_TYPE = "Ed25519VerificationKey2020";
 
+  /** The constant PUBLIC_KEY_BASE_58. */
   public static final String PUBLIC_KEY_BASE_58 = "publicKeyMultibase";
 
+  /**
+   * Is instance boolean.
+   *
+   * @param json the json
+   * @return the boolean
+   */
   public static boolean isInstance(Map<String, Object> json) {
     return DEFAULT_TYPE.equals(json.get(TYPE));
   }
 
+  /**
+   * Instantiates a new Ed 25519 verification method.
+   *
+   * @param json the json
+   */
   public Ed25519VerificationMethod(Map<String, Object> json) {
     super(json);
 
@@ -55,6 +69,11 @@ public class Ed25519VerificationMethod extends VerificationMethod {
     }
   }
 
+  /**
+   * Gets public key base 58.
+   *
+   * @return the public key base 58
+   */
   public MultibaseString getPublicKeyBase58() {
     return MultibaseFactory.create((String) this.get(PUBLIC_KEY_BASE_58));
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
@@ -38,7 +38,7 @@ public class Ed25519VerificationMethod extends VerificationMethod {
   public static final String PUBLIC_KEY_BASE_58 = "publicKeyMultibase";
 
   /**
-   * Is instance boolean.
+   * Check if Is instance.
    *
    * @param json the json
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethodBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethodBuilder.java
@@ -26,27 +26,51 @@ import java.util.Map;
 import lombok.NoArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 
+/** The type Ed 25519 verification method builder. */
 @NoArgsConstructor
 public class Ed25519VerificationMethodBuilder {
   private URI id;
   private URI controller;
   private String publicKeyMultiBase;
 
+  /**
+   * Id ed 25519 verification method builder.
+   *
+   * @param id the id
+   * @return the ed 25519 verification method builder
+   */
   public Ed25519VerificationMethodBuilder id(URI id) {
     this.id = id;
     return this;
   }
 
+  /**
+   * Controller ed 25519 verification method builder.
+   *
+   * @param controller the controller
+   * @return the ed 25519 verification method builder
+   */
   public Ed25519VerificationMethodBuilder controller(URI controller) {
     this.controller = controller;
     return this;
   }
 
+  /**
+   * Public key multi base ed 25519 verification method builder.
+   *
+   * @param multibaseString the multibase string
+   * @return the ed 25519 verification method builder
+   */
   public Ed25519VerificationMethodBuilder publicKeyMultiBase(MultibaseString multibaseString) {
     this.publicKeyMultiBase = multibaseString.getEncoded();
     return this;
   }
 
+  /**
+   * Build ed 25519 verification method.
+   *
+   * @return the ed 25519 verification method
+   */
   public Ed25519VerificationMethod build() {
     return new Ed25519VerificationMethod(
         Map.of(

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
@@ -28,14 +28,25 @@ import lombok.Data;
 import lombok.ToString;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Jwk verification method. */
 @ToString
 public class JWKVerificationMethod extends VerificationMethod {
+  /** The constant DEFAULT_TYPE. */
   public static final String DEFAULT_TYPE = "JsonWebKey2020";
+  /** The constant PUBLIC_KEY_JWK. */
   public static final String PUBLIC_KEY_JWK = "publicKeyJwk";
+  /** The constant JWK_KEK_TYPE. */
   public static final String JWK_KEK_TYPE = "kty";
+  /** The constant JWK_CURVE. */
   public static final String JWK_CURVE = "crv";
+  /** The constant JWK_X. */
   public static final String JWK_X = "x";
 
+  /**
+   * Instantiates a new Jwk verification method.
+   *
+   * @param json the json
+   */
   public JWKVerificationMethod(Map<String, Object> json) {
     super(json);
 
@@ -53,6 +64,11 @@ public class JWKVerificationMethod extends VerificationMethod {
     }
   }
 
+  /**
+   * Gets public key jwk.
+   *
+   * @return the public key jwk
+   */
   public PublicKeyJwk getPublicKeyJwk() {
     var publicKeyJwk = (Map<String, String>) this.get(PUBLIC_KEY_JWK);
 
@@ -60,10 +76,17 @@ public class JWKVerificationMethod extends VerificationMethod {
         publicKeyJwk.get(JWK_KEK_TYPE), publicKeyJwk.get(JWK_CURVE), publicKeyJwk.get(JWK_X));
   }
 
+  /**
+   * Is instance boolean.
+   *
+   * @param json the json
+   * @return the boolean
+   */
   public static boolean isInstance(Map<String, Object> json) {
     return DEFAULT_TYPE.equals(json.get(TYPE));
   }
 
+  /** The type Public key jwk. */
   @Data
   @AllArgsConstructor
   public static class PublicKeyJwk {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
@@ -77,7 +77,7 @@ public class JWKVerificationMethod extends VerificationMethod {
   }
 
   /**
-   * Is instance boolean.
+   * Check if is instance.
    *
    * @param json the json
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethodBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethodBuilder.java
@@ -26,21 +26,39 @@ import java.util.Map;
 import lombok.NoArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.crypt.jwk.JsonWebKey;
 
+/** The type Jwk verification method builder. */
 @NoArgsConstructor
 public class JWKVerificationMethodBuilder {
   private Did did;
   private JsonWebKey jwk;
 
+  /**
+   * Did jwk verification method builder.
+   *
+   * @param did the did
+   * @return the jwk verification method builder
+   */
   public JWKVerificationMethodBuilder did(Did did) {
     this.did = did;
     return this;
   }
 
+  /**
+   * Jwk jwk verification method builder.
+   *
+   * @param jwk the jwk
+   * @return the jwk verification method builder
+   */
   public JWKVerificationMethodBuilder jwk(JsonWebKey jwk) {
     this.jwk = jwk;
     return this;
   }
 
+  /**
+   * Build jwk verification method.
+   *
+   * @return the jwk verification method
+   */
   public JWKVerificationMethod build() {
     return new JWKVerificationMethod(
         Map.of(

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/VerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/VerificationMethod.java
@@ -28,13 +28,24 @@ import java.util.Objects;
 import lombok.ToString;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
-// spec https://www.w3.org/TR/did-core/#verification-methods
+/**
+ * The type Verification method. Spec: <a
+ * href="https://www.w3.org/TR/did-core/#verification-methods">...</a>
+ */
 @ToString
 public class VerificationMethod extends HashMap<String, Object> {
+  /** The constant ID. */
   public static final String ID = "id";
+  /** The constant TYPE. */
   public static final String TYPE = "type";
+  /** The constant CONTROLLER. */
   public static final String CONTROLLER = "controller";
 
+  /**
+   * Instantiates a new Verification method.
+   *
+   * @param json the json
+   */
   public VerificationMethod(Map<String, Object> json) {
     super(json);
 
@@ -49,14 +60,29 @@ public class VerificationMethod extends HashMap<String, Object> {
     }
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   public URI getId() {
     return SerializeUtil.asURI(this.get(ID));
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public String getType() {
     return (String) this.get(TYPE);
   }
 
+  /**
+   * Gets controller.
+   *
+   * @return the controller
+   */
   public URI getController() {
     return SerializeUtil.asURI(this.get(CONTROLLER));
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/Proof.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/Proof.java
@@ -25,10 +25,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/** The type Proof. */
 public class Proof extends HashMap<String, Object> {
 
+  /** The constant TYPE. */
   public static final String TYPE = "type";
 
+  /**
+   * Instantiates a new Proof.
+   *
+   * @param json the json
+   */
   public Proof(Map<String, Object> json) {
     super(json);
 
@@ -40,6 +47,11 @@ public class Proof extends HashMap<String, Object> {
     }
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public String getType() {
     return (String) this.get(TYPE);
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/ed21559/Ed25519Signature2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/ed21559/Ed25519Signature2020.java
@@ -31,22 +31,36 @@ import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
 /**
- * E.g. "proof": { "type": "Ed25519Signature2020", "created": "2021-11-13T18:19:39Z",
+ * The type of {@link Ed25519Signature2020}
+ *
+ * <p>E.g. "proof": { "type": "Ed25519Signature2020", "created": "2021-11-13T18:19:39Z",
  * "verificationMethod": "https://example.edu/issuers/14#key-1", "proofPurpose": "assertionMethod",
  * "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndSayn1PzZs6ZjWp1CktyGesjuTSwRdo
  * WhAfGFCF5bppETSTojQCrfFPP2oumHKtz" }
  */
 public class Ed25519Signature2020 extends Proof {
 
+  /** The constant ED25519_VERIFICATION_KEY_2018. */
   public static final String ED25519_VERIFICATION_KEY_2018 = "Ed25519Signature2020";
+  /** The constant TIME_FORMAT. */
   public static final String TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
+  /** The constant ASSERTION_METHOD. */
   public static final String ASSERTION_METHOD = "assertionMethod";
+  /** The constant PROOF_PURPOSE. */
   public static final String PROOF_PURPOSE = "proofPurpose";
+  /** The constant PROOF_VALUE. */
   public static final String PROOF_VALUE = "proofValue";
+  /** The constant CREATED. */
   public static final String CREATED = "created";
+  /** The constant VERIFICATION_METHOD. */
   public static final String VERIFICATION_METHOD = "verificationMethod";
 
+  /**
+   * Instantiates a new Ed 25519 signature 2020.
+   *
+   * @param json the json
+   */
   public Ed25519Signature2020(Map<String, Object> json) {
     super(json);
 
@@ -65,18 +79,38 @@ public class Ed25519Signature2020 extends Proof {
     }
   }
 
+  /**
+   * Gets proof purpose.
+   *
+   * @return the proof purpose
+   */
   public String getProofPurpose() {
     return (String) this.get(PROOF_PURPOSE);
   }
 
+  /**
+   * Gets proof value.
+   *
+   * @return the proof value
+   */
   public MultibaseString getProofValue() {
     return MultibaseFactory.create((String) this.get(PROOF_VALUE));
   }
 
+  /**
+   * Gets verification method.
+   *
+   * @return the verification method
+   */
   public URI getVerificationMethod() {
     return SerializeUtil.asURI(this.get(VERIFICATION_METHOD));
   }
 
+  /**
+   * Gets created.
+   *
+   * @return the created
+   */
   public Instant getCreated() {
     return Instant.parse((String) this.get(CREATED));
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/ed21559/Ed25519Signature2020Builder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/ed21559/Ed25519Signature2020Builder.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import lombok.NoArgsConstructor;
 
+/** The type Ed 25519 signature 2020 builder. */
 @NoArgsConstructor
 public class Ed25519Signature2020Builder {
 
@@ -36,26 +37,55 @@ public class Ed25519Signature2020Builder {
   private URI verificationMethod;
   private Instant created;
 
+  /**
+   * Proof purpose ed 25519 signature 2020 builder.
+   *
+   * @param proofPurpose the proof purpose
+   * @return the ed 25519 signature 2020 builder
+   */
   public Ed25519Signature2020Builder proofPurpose(String proofPurpose) {
     this.proofPurpose = proofPurpose;
     return this;
   }
 
+  /**
+   * Proof value ed 25519 signature 2020 builder.
+   *
+   * @param proofValue the proof value
+   * @return the ed 25519 signature 2020 builder
+   */
   public Ed25519Signature2020Builder proofValue(String proofValue) {
     this.proofValue = proofValue;
     return this;
   }
 
+  /**
+   * Verification method ed 25519 signature 2020 builder.
+   *
+   * @param verificationMethod the verification method
+   * @return the ed 25519 signature 2020 builder
+   */
   public Ed25519Signature2020Builder verificationMethod(URI verificationMethod) {
     this.verificationMethod = verificationMethod;
     return this;
   }
 
+  /**
+   * Created ed 25519 signature 2020 builder.
+   *
+   * @param created the created
+   * @return the ed 25519 signature 2020 builder
+   */
   public Ed25519Signature2020Builder created(Instant created) {
     this.created = created;
     return this;
   }
 
+  /**
+   * Build ed 25519 signature 2020.
+   *
+   * @return the ed 25519 signature 2020
+   */
   public Ed25519Signature2020 build() {
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern(Ed25519Signature2020.TIME_FORMAT).withZone(ZoneOffset.UTC);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/jws/JWSSignature2020.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/jws/JWSSignature2020.java
@@ -29,22 +29,36 @@ import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
 /**
- * E.g. "proof": {"type": "JsonWebSignature2020", "created": "2019-12-11T03:50:55Z", "jws":
+ * The type of Ed25519Signature2020
+ *
+ * <p>E.g. "proof": {"type": "JsonWebSignature2020", "created": "2019-12-11T03:50:55Z", "jws":
  * "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MJ5GwWRMsadCyLNXU_flgJtsS32584MydBxBuygps_cM0sbU3abTEOMyUvmLNcKOwOBE1MfDoB1_YY425W3sAg",
  * "proofPurpose": "assertionMethod", "verificationMethod":
  * "https://example.com/issuer/123#ovsDKYBjFemIy8DVhc-w2LSi8CvXMw2AYDzHj04yxkc"}
  */
 public class JWSSignature2020 extends Proof {
 
+  /** The constant JWS_VERIFICATION_KEY_2020. */
   public static final String JWS_VERIFICATION_KEY_2020 = "JsonWebSignature2020";
+  /** The constant TIME_FORMAT. */
   public static final String TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
+  /** The constant ASSERTION_METHOD. */
   public static final String ASSERTION_METHOD = "assertionMethod";
+  /** The constant PROOF_PURPOSE. */
   public static final String PROOF_PURPOSE = "proofPurpose";
+  /** The constant JWS. */
   public static final String JWS = "jws";
+  /** The constant CREATED. */
   public static final String CREATED = "created";
+  /** The constant VERIFICATION_METHOD. */
   public static final String VERIFICATION_METHOD = "verificationMethod";
 
+  /**
+   * Instantiates a new Jws signature 2020.
+   *
+   * @param json the json
+   */
   public JWSSignature2020(Map<String, Object> json) {
     super(json);
 
@@ -63,18 +77,38 @@ public class JWSSignature2020 extends Proof {
     }
   }
 
+  /**
+   * Gets proof purpose.
+   *
+   * @return the proof purpose
+   */
   public String getProofPurpose() {
     return (String) this.get(PROOF_PURPOSE);
   }
 
+  /**
+   * Gets jws.
+   *
+   * @return the jws
+   */
   public String getJws() {
     return (String) this.get(JWS);
   }
 
+  /**
+   * Gets verification method.
+   *
+   * @return the verification method
+   */
   public URI getVerificationMethod() {
     return SerializeUtil.asURI(this.get(VERIFICATION_METHOD));
   }
 
+  /**
+   * Gets created.
+   *
+   * @return the created
+   */
   public Instant getCreated() {
     return Instant.parse((String) this.get(CREATED));
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/jws/JWSSignature2020Builder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/proof/jws/JWSSignature2020Builder.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import lombok.NoArgsConstructor;
 
+/** The type Jws signature 2020 builder. */
 @NoArgsConstructor
 public class JWSSignature2020Builder {
 
@@ -36,26 +37,55 @@ public class JWSSignature2020Builder {
   private URI verificationMethod;
   private Instant created;
 
+  /**
+   * Proof purpose jws signature 2020 builder.
+   *
+   * @param proofPurpose the proof purpose
+   * @return the jws signature 2020 builder
+   */
   public JWSSignature2020Builder proofPurpose(String proofPurpose) {
     this.proofPurpose = proofPurpose;
     return this;
   }
 
+  /**
+   * Proof value jws signature 2020 builder.
+   *
+   * @param proofValue the proof value
+   * @return the jws signature 2020 builder
+   */
   public JWSSignature2020Builder proofValue(String proofValue) {
     this.jws = proofValue;
     return this;
   }
 
+  /**
+   * Verification method jws signature 2020 builder.
+   *
+   * @param verificationMethod the verification method
+   * @return the jws signature 2020 builder
+   */
   public JWSSignature2020Builder verificationMethod(URI verificationMethod) {
     this.verificationMethod = verificationMethod;
     return this;
   }
 
+  /**
+   * Created jws signature 2020 builder.
+   *
+   * @param created the created
+   * @return the jws signature 2020 builder
+   */
   public JWSSignature2020Builder created(Instant created) {
     this.created = created;
     return this;
   }
 
+  /**
+   * Build jws signature 2020.
+   *
+   * @return the jws signature 2020
+   */
   public JWSSignature2020 build() {
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern(JWSSignature2020.TIME_FORMAT).withZone(ZoneOffset.UTC);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/Verifiable.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/Verifiable.java
@@ -30,19 +30,33 @@ import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Verifiable. */
 public abstract class Verifiable extends JsonLdObject {
 
+  /** The constant ID. */
   public static final String ID = "id";
+  /** The constant TYPE. */
   public static final String TYPE = "type";
+  /** The constant PROOF. */
   public static final String PROOF = "proof";
 
+  /** The verification type */
   private VerifiableType verifableType;
 
+  /** The enum Verifiable type. */
   public enum VerifiableType {
+    /** Vc verifiable type. */
     VC,
+    /** Vp verifiable type. */
     VP
   }
 
+  /**
+   * Instantiates a new Verifiable.
+   *
+   * @param json the json
+   * @param type the type
+   */
   public Verifiable(Map<String, Object> json, VerifiableType type) {
     super(json);
     Objects.requireNonNull(this.getId());
@@ -52,16 +66,31 @@ public abstract class Verifiable extends JsonLdObject {
     this.checkId();
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @NonNull
   public URI getId() {
     return SerializeUtil.asURI(this.get(ID));
   }
 
+  /**
+   * Gets types.
+   *
+   * @return the types
+   */
   @NonNull
   public List<String> getTypes() {
     return (List<String>) this.get(TYPE);
   }
 
+  /**
+   * Gets proof.
+   *
+   * @return the proof
+   */
   public Proof getProof() {
 
     final Object subject = this.get(PROOF);
@@ -73,6 +102,11 @@ public abstract class Verifiable extends JsonLdObject {
     return new Proof((Map<String, Object>) subject);
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public VerifiableType getType() {
     return verifableType;
   }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredential.java
@@ -35,7 +35,9 @@ import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
 // @formatter:off
 /**
- * Verifiable Credential e.g. from
+ * The type of VerifiableCredential Spec: <a href="https://www.w3.org/TR/vc-data-model/">...</a>
+ *
+ * <p>Verifiable Credential e.g. from
  * https://www.w3.org/TR/vc-data-model/#example-usage-of-the-credentialsubject-property {
  * "@context": [ "https://www.w3.org/2018/credentials/v1",
  * "https://www.w3.org/2018/credentials/examples/v1", "https://w3id.org/secu
@@ -52,24 +54,41 @@ import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 @ToString(callSuper = true)
 public class VerifiableCredential extends Verifiable {
 
+  /** The constant DEFAULT_CONTEXT. */
   public static final URI DEFAULT_CONTEXT = URI.create("https://www.w3.org/2018/credentials/v1");
+  /** The constant TIME_FORMAT. */
   public static final String TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  /** The constant ISSUER. */
   public static final String ISSUER = "issuer";
+  /** The constant ISSUANCE_DATE. */
   public static final String ISSUANCE_DATE = "issuanceDate";
+  /** The constant EXPIRATION_DATE. */
   public static final String EXPIRATION_DATE = "expirationDate";
+  /** The constant CREDENTIAL_SUBJECT. */
   public static final String CREDENTIAL_SUBJECT = "credentialSubject";
+  /** The constant CREDENTIAL_STATUS. */
   public static final String CREDENTIAL_STATUS = "credentialStatus";
 
+  /** The constant CREDENTIAL_SCHEMA. */
   public static final String CREDENTIAL_SCHEMA = "credentialSchema";
 
+  /** The constant REFERENCE_NUMBER. */
   public static final String REFERENCE_NUMBER = "referenceNumber";
 
+  /** The constant EVIDENCE. */
   public static final String EVIDENCE = "evidence";
 
+  /** The constant TERMS_OF_USE. */
   public static final String TERMS_OF_USE = "termsOfUse";
 
+  /** The constant REFRESH_SERVICE. */
   public static final String REFRESH_SERVICE = "refreshService";
 
+  /**
+   * Instantiates a new Verifiable credential.
+   *
+   * @param json the json
+   */
   @JsonCreator
   public VerifiableCredential(Map<String, Object> json) {
     super(json, VerifiableType.VC);
@@ -107,16 +126,31 @@ public class VerifiableCredential extends Verifiable {
     return SerializeUtil.asStringList(get(TYPE));
   }
 
+  /**
+   * Gets issuer.
+   *
+   * @return the issuer
+   */
   @NonNull
   public URI getIssuer() {
     return SerializeUtil.asURI(get(ISSUER));
   }
 
+  /**
+   * Gets issuance date.
+   *
+   * @return the issuance date
+   */
   @NonNull
   public Instant getIssuanceDate() {
     return Instant.parse((String) get(ISSUANCE_DATE));
   }
 
+  /**
+   * Gets expiration date.
+   *
+   * @return the expiration date
+   */
   public Instant getExpirationDate() {
     if (!containsKey(EXPIRATION_DATE)) {
       return null;
@@ -124,6 +158,11 @@ public class VerifiableCredential extends Verifiable {
     return Instant.parse((String) get(EXPIRATION_DATE));
   }
 
+  /**
+   * Gets credential subject.
+   *
+   * @return the credential subject
+   */
   @NonNull
   public List<VerifiableCredentialSubject> getCredentialSubject() {
     Object subject = get(CREDENTIAL_SUBJECT);
@@ -141,6 +180,11 @@ public class VerifiableCredential extends Verifiable {
     }
   }
 
+  /**
+   * Gets verifiable credential status.
+   *
+   * @return the verifiable credential status
+   */
   public VerifiableCredentialStatus getVerifiableCredentialStatus() {
     Object data = get(CREDENTIAL_STATUS);
     if (data == null) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialBuilder.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import lombok.NoArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 
+/** The type Verifiable credential builder. */
 @NoArgsConstructor
 public class VerifiableCredentialBuilder {
 
@@ -44,59 +45,124 @@ public class VerifiableCredentialBuilder {
   private Proof proof;
   private VerifiableCredentialStatus credentialStatus;
 
+  /**
+   * Context verifiable credential builder.
+   *
+   * @param context the context
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder context(List<URI> context) {
     this.context = context;
     return this;
   }
 
+  /**
+   * Id verifiable credential builder.
+   *
+   * @param id the id
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder id(URI id) {
     this.id = id;
     return this;
   }
 
+  /**
+   * Type verifiable credential builder.
+   *
+   * @param types the types
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder type(List<String> types) {
     this.types = types;
     return this;
   }
 
+  /**
+   * Issuer verifiable credential builder.
+   *
+   * @param issuer the issuer
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder issuer(URI issuer) {
     this.issuer = issuer;
     return this;
   }
 
+  /**
+   * Issuance date verifiable credential builder.
+   *
+   * @param issuanceDate the issuance date
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder issuanceDate(Instant issuanceDate) {
     this.issuanceDate = issuanceDate;
     return this;
   }
 
+  /**
+   * Expiration date verifiable credential builder.
+   *
+   * @param expirationDate the expiration date
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder expirationDate(Instant expirationDate) {
     this.expirationDate = expirationDate;
     return this;
   }
 
+  /**
+   * Credential subject verifiable credential builder.
+   *
+   * @param credentialSubject the credential subject
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder credentialSubject(
       List<VerifiableCredentialSubject> credentialSubject) {
     this.credentialSubject = credentialSubject;
     return this;
   }
 
+  /**
+   * Credential subject verifiable credential builder.
+   *
+   * @param credentialSubject the credential subject
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder credentialSubject(
       VerifiableCredentialSubject credentialSubject) {
     this.credentialSubject = List.of(credentialSubject);
     return this;
   }
 
+  /**
+   * Proof verifiable credential builder.
+   *
+   * @param proof the proof
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder proof(Proof proof) {
     this.proof = proof;
     return this;
   }
 
+  /**
+   * Verifiable credential status verifiable credential builder.
+   *
+   * @param credentialStatus the credential status
+   * @return the verifiable credential builder
+   */
   public VerifiableCredentialBuilder verifiableCredentialStatus(
       VerifiableCredentialStatus credentialStatus) {
     this.credentialStatus = credentialStatus;
     return this;
   }
 
+  /**
+   * Build verifiable credential.
+   *
+   * @return the verifiable credential
+   */
   public VerifiableCredential build() {
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern(VerifiableCredential.TIME_FORMAT).withZone(ZoneOffset.UTC);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialSubject.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialSubject.java
@@ -26,10 +26,17 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Verifiable credential subject. */
 public class VerifiableCredentialSubject extends HashMap<String, Object> {
 
+  /** The constant ID. */
   public static final String ID = "id";
 
+  /**
+   * Instantiates a new Verifiable credential subject.
+   *
+   * @param json the json
+   */
   public VerifiableCredentialSubject(Map<String, Object> json) {
     super(json);
 
@@ -42,6 +49,11 @@ public class VerifiableCredentialSubject extends HashMap<String, Object> {
     }
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   public URI getId() {
     Object id = this.get(ID);
     return id == null ? null : SerializeUtil.asURI(id);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialType.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialType.java
@@ -21,7 +21,10 @@
 
 package org.eclipse.tractusx.ssi.lib.model.verifiable.credential;
 
+/** The type Verifiable credential type. */
 public class VerifiableCredentialType {
+  /** The constant VERIFIABLE_CREDENTIAL. */
   public static final String VERIFIABLE_CREDENTIAL = "VerifiableCredential";
+  /** The constant MEMBERSHIP_CREDENTIAL. */
   public static final String MEMBERSHIP_CREDENTIAL = "MembershipCredential";
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentials.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentials.java
@@ -23,4 +23,5 @@ package org.eclipse.tractusx.ssi.lib.model.verifiable.credential;
 
 import java.util.ArrayList;
 
+/** The type Verifiable credentials. */
 public class VerifiableCredentials extends ArrayList<VerifiableCredential> {}

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentation.java
@@ -32,12 +32,20 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 
+/** The type Verifiable presentation. */
 @ToString(callSuper = true)
 public class VerifiablePresentation extends Verifiable {
+  /** The constant DEFAULT_CONTEXT. */
   public static final URI DEFAULT_CONTEXT = URI.create("https://www.w3.org/2018/credentials/v1");
 
+  /** The constant VERIFIABLE_CREDENTIAL. */
   public static final String VERIFIABLE_CREDENTIAL = "verifiableCredential";
 
+  /**
+   * Instantiates a new Verifiable presentation.
+   *
+   * @param json the json
+   */
   public VerifiablePresentation(Map<String, Object> json) {
     super(json, VerifiableType.VP);
 
@@ -51,11 +59,22 @@ public class VerifiablePresentation extends Verifiable {
     }
   }
 
+  /**
+   * From json verifiable presentation.
+   *
+   * @param json the json
+   * @return the verifiable presentation
+   */
   public static VerifiablePresentation fromJson(String json) {
     var map = SerializeUtil.fromJson(json);
     return new VerifiablePresentation(map);
   }
 
+  /**
+   * Gets verifiable credentials.
+   *
+   * @return the verifiable credentials
+   */
   @NonNull
   public List<VerifiableCredential> getVerifiableCredentials() {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationBuilder.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationBuilder.java
@@ -29,6 +29,7 @@ import lombok.NoArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.model.proof.Proof;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 
+/** The type Verifiable presentation builder. */
 @NoArgsConstructor
 public class VerifiablePresentationBuilder {
   private List<URI> context = List.of(VerifiablePresentation.DEFAULT_CONTEXT);
@@ -37,32 +38,67 @@ public class VerifiablePresentationBuilder {
   private List<VerifiableCredential> verifiableCredentials;
   private Proof proof;
 
+  /**
+   * Context verifiable presentation builder.
+   *
+   * @param context the context
+   * @return the verifiable presentation builder
+   */
   public VerifiablePresentationBuilder context(List<URI> context) {
     this.context = context;
     return this;
   }
 
+  /**
+   * Id verifiable presentation builder.
+   *
+   * @param id the id
+   * @return the verifiable presentation builder
+   */
   public VerifiablePresentationBuilder id(URI id) {
     this.id = id;
     return this;
   }
 
+  /**
+   * Type verifiable presentation builder.
+   *
+   * @param types the types
+   * @return the verifiable presentation builder
+   */
   public VerifiablePresentationBuilder type(List<String> types) {
     this.types = types;
     return this;
   }
 
+  /**
+   * Verifiable credentials verifiable presentation builder.
+   *
+   * @param verifiableCredentials the verifiable credentials
+   * @return the verifiable presentation builder
+   */
   public VerifiablePresentationBuilder verifiableCredentials(
       List<VerifiableCredential> verifiableCredentials) {
     this.verifiableCredentials = verifiableCredentials;
     return this;
   }
 
+  /**
+   * Proof verifiable presentation builder.
+   *
+   * @param proof the proof
+   * @return the verifiable presentation builder
+   */
   public VerifiablePresentationBuilder proof(Proof proof) {
     this.proof = proof;
     return this;
   }
 
+  /**
+   * Build verifiable presentation.
+   *
+   * @return the verifiable presentation
+   */
   public VerifiablePresentation build() {
     Map<String, Object> map = new HashMap<>();
     map.put(VerifiablePresentation.CONTEXT, context);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationType.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationType.java
@@ -21,6 +21,8 @@
 
 package org.eclipse.tractusx.ssi.lib.model.verifiable.presentation;
 
+/** The type Verifiable presentation type. */
 public class VerifiablePresentationType {
+  /** The constant VERIFIABLE_PRESENTATION. */
   public static final String VERIFIABLE_PRESENTATION = "VerifiablePresentation";
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/ISigner.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/ISigner.java
@@ -26,7 +26,17 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidePrivateKeyFormat;
 import org.eclipse.tractusx.ssi.lib.exception.SsiException;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The interface Signer. */
 public interface ISigner {
+  /**
+   * Sign byte [ ].
+   *
+   * @param hashedLinkedData the hashed linked data
+   * @param privateKey the private key
+   * @return the byte [ ]
+   * @throws SsiException the ssi exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   */
   public byte[] sign(HashedLinkedData hashedLinkedData, IPrivateKey privateKey)
       throws SsiException, InvalidePrivateKeyFormat;
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/IVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/IVerifier.java
@@ -29,13 +29,20 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The interface Verifier. */
 public interface IVerifier {
   /**
    * {@link VerifiableCredential} verification method, This method depends on Issuer in VC data
    * model to get the public key of issuer.
    *
-   * @param hashedLinkedData
-   * @param document {@link VerifiableCredential}
+   * @param hashedLinkedData the hashed linked data
+   * @param verifiable the verifiable
+   * @return the boolean
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws DidDocumentResolverNotRegisteredException the did document resolver not registered
+   *     exception
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   * @throws NoVerificationKeyFoundExcpetion the no verification key found excpetion
    */
   public boolean verify(HashedLinkedData hashedLinkedData, Verifiable verifiable)
       throws UnsupportedSignatureTypeException, DidDocumentResolverNotRegisteredException,

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofGenerator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofGenerator.java
@@ -44,9 +44,17 @@ import org.eclipse.tractusx.ssi.lib.proof.transform.TransformedLinkedData;
 import org.eclipse.tractusx.ssi.lib.proof.types.ed25519.Ed25519ProofSigner;
 import org.eclipse.tractusx.ssi.lib.proof.types.jws.JWSProofSigner;
 
+/** The type Linked data proof generator. */
 @RequiredArgsConstructor
 public class LinkedDataProofGenerator {
 
+  /**
+   * New instance linked data proof generator.
+   *
+   * @param type the type
+   * @return the linked data proof generator
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   */
   public static LinkedDataProofGenerator newInstance(SignatureType type)
       throws UnsupportedSignatureTypeException {
     if (type == SignatureType.ED21559) {
@@ -65,6 +73,16 @@ public class LinkedDataProofGenerator {
   private final LinkedDataTransformer transformer;
   private final ISigner signer;
 
+  /**
+   * Create proof.
+   *
+   * @param document the document
+   * @param verificationMethodId the verification method id
+   * @param privateKey the private key
+   * @return the proof
+   * @throws SsiException the ssi exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   */
   public Proof createProof(Verifiable document, URI verificationMethodId, IPrivateKey privateKey)
       throws SsiException, InvalidePrivateKeyFormat {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofValidation.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofValidation.java
@@ -38,9 +38,16 @@ import org.eclipse.tractusx.ssi.lib.proof.types.jws.JWSProofVerifier;
 import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.JsonLdValidator;
 import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.JsonLdValidatorImpl;
 
+/** The type Linked data proof validation. */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class LinkedDataProofValidation {
 
+  /**
+   * New instance linked data proof validation.
+   *
+   * @param didResolver the did resolver
+   * @return the linked data proof validation
+   */
   public static LinkedDataProofValidation newInstance(DidResolver didResolver) {
 
     if (didResolver == null) {
@@ -63,6 +70,9 @@ public class LinkedDataProofValidation {
    * To verify {@link VerifiableCredential} or {@link VerifiablePresentation}. In this method we are
    * depending on Verification Method to resolve the DID Document and fetching the required Public
    * Key
+   *
+   * @param verifiable the verifiable
+   * @return the boolean
    */
   @SneakyThrows
   public boolean verify(Verifiable verifiable) {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/SignatureType.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/SignatureType.java
@@ -21,12 +21,15 @@
 
 package org.eclipse.tractusx.ssi.lib.proof;
 
+/** The enum Signature type. */
 public enum SignatureType {
+  /** The Ed 21559. */
   ED21559 {
     public String toString() {
       return "Ed25519Signature2020";
     }
   },
+  /** The Jws. */
   JWS {
     public String toString() {
       return "JsonWebSignature2020";

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/HashedLinkedData.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/HashedLinkedData.java
@@ -24,6 +24,7 @@ package org.eclipse.tractusx.ssi.lib.proof.hash;
 import lombok.NonNull;
 import lombok.Value;
 
+/** The type Hashed linked data. */
 @Value
 public class HashedLinkedData {
   byte @NonNull [] value;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/LinkedDataHasher.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/LinkedDataHasher.java
@@ -25,8 +25,15 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.eclipse.tractusx.ssi.lib.proof.transform.TransformedLinkedData;
 
+/** The type Linked data hasher. */
 public class LinkedDataHasher {
 
+  /**
+   * Hash hashed linked data.
+   *
+   * @param transformedLinkedData the transformed linked data
+   * @return the hashed linked data
+   */
   public HashedLinkedData hash(TransformedLinkedData transformedLinkedData) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/LinkedDataHasher.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/hash/LinkedDataHasher.java
@@ -29,7 +29,7 @@ import org.eclipse.tractusx.ssi.lib.proof.transform.TransformedLinkedData;
 public class LinkedDataHasher {
 
   /**
-   * Hash hashed linked data.
+   * Hash linked data.
    *
    * @param transformedLinkedData the transformed linked data
    * @return the hashed linked data

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/LinkedDataTransformer.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/LinkedDataTransformer.java
@@ -43,7 +43,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 public class LinkedDataTransformer {
 
   /**
-   * Transform transformed linked data.
+   * Transform linked data.
    *
    * @param document the document
    * @return the transformed linked data

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/LinkedDataTransformer.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/LinkedDataTransformer.java
@@ -39,8 +39,15 @@ import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 import org.eclipse.tractusx.ssi.lib.model.RemoteDocumentLoader;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 
+/** The type Linked data transformer. */
 public class LinkedDataTransformer {
 
+  /**
+   * Transform transformed linked data.
+   *
+   * @param document the document
+   * @return the transformed linked data
+   */
   @SneakyThrows
   public TransformedLinkedData transform(Verifiable document) {
     // Make a copy and remove proof, as it is not part of the linked data

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/TransformedLinkedData.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/transform/TransformedLinkedData.java
@@ -25,6 +25,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Value;
 
+/** The type Transformed linked data. */
 @Value
 @EqualsAndHashCode(of = "value")
 public class TransformedLinkedData {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/ed25519/Ed25519ProofSigner.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/ed25519/Ed25519ProofSigner.java
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.ssi.lib.exception.SsiException;
 import org.eclipse.tractusx.ssi.lib.proof.ISigner;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The type Ed 25519 proof signer. */
 public class Ed25519ProofSigner implements ISigner {
 
   @Override

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/ed25519/Ed25519ProofVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/ed25519/Ed25519ProofVerifier.java
@@ -47,6 +47,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 import org.eclipse.tractusx.ssi.lib.proof.IVerifier;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The type Ed 25519 proof verifier. */
 @RequiredArgsConstructor
 public class Ed25519ProofVerifier implements IVerifier {
 
@@ -101,6 +102,14 @@ public class Ed25519ProofVerifier implements IVerifier {
     return publicKey;
   }
 
+  /**
+   * Verify hashedLinkedData.
+   *
+   * @param hashedLinkedData the hashed linked data
+   * @param signature the signature
+   * @param publicKey the public key
+   * @return the boolean the verification result
+   */
   @SneakyThrows
   public boolean verify(HashedLinkedData hashedLinkedData, byte[] signature, IPublicKey publicKey) {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofSigner.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofSigner.java
@@ -37,6 +37,7 @@ import org.eclipse.tractusx.ssi.lib.exception.SsiException;
 import org.eclipse.tractusx.ssi.lib.proof.ISigner;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The type Jws proof signer. */
 public class JWSProofSigner implements ISigner {
 
   @Override

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofVerifier.java
@@ -124,7 +124,7 @@ public class JWSProofVerifier implements IVerifier {
   }
 
   /**
-   * Verify boolean.
+   * Verify hashedLinkedData.
    *
    * @param hashedLinkedData the hashed linked data
    * @param signature the signature

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/proof/types/jws/JWSProofVerifier.java
@@ -51,6 +51,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.Verifiable;
 import org.eclipse.tractusx.ssi.lib.proof.IVerifier;
 import org.eclipse.tractusx.ssi.lib.proof.hash.HashedLinkedData;
 
+/** The type Jws proof verifier. */
 @RequiredArgsConstructor
 public class JWSProofVerifier implements IVerifier {
 
@@ -122,6 +123,14 @@ public class JWSProofVerifier implements IVerifier {
     return keyPair;
   }
 
+  /**
+   * Verify boolean.
+   *
+   * @param hashedLinkedData the hashed linked data
+   * @param signature the signature
+   * @param publicKey the public key
+   * @return the boolean
+   */
   @SneakyThrows
   public boolean verify(HashedLinkedData hashedLinkedData, byte[] signature, IPublicKey publicKey) {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
@@ -82,16 +82,34 @@ public final class SerializeUtil {
               VerifiablePresentation.VERIFIABLE_CREDENTIAL,
               VerifiableCredential.PROOF));
 
+  /**
+   * To json string.
+   *
+   * @param map the map
+   * @return the string
+   */
   @SneakyThrows
   public static String toJson(Map<String, Object> map) {
     return OBJECT_MAPPER.writeValueAsString(getLinkedHashMap(map));
   }
 
+  /**
+   * To pretty json string.
+   *
+   * @param map the map
+   * @return the string
+   */
   @SneakyThrows
   public static String toPrettyJson(Map<String, Object> map) {
     return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(getLinkedHashMap(map));
   }
 
+  /**
+   * From json map.
+   *
+   * @param json the json
+   * @return the map
+   */
   @SneakyThrows
   public static Map<String, Object> fromJson(String json) {
     return OBJECT_MAPPER.readValue(json, Map.class);
@@ -99,10 +117,10 @@ public final class SerializeUtil {
 
   /**
    * Sometimes SSI uri is serialized as string, sometimes as URI. If it starts with 'http://' it is
-   * handled as URI, if it starts with 'did:<method>' it is handled as string.
+   * handled as URI, if it starts with 'did:method' it is handled as string.
    *
    * @param object string or URI
-   * @return URI
+   * @return URI uri
    */
   public static URI asURI(Object object) {
     if (object instanceof URI) {
@@ -114,6 +132,12 @@ public final class SerializeUtil {
     throw new IllegalArgumentException("Unsupported type: " + object.getClass());
   }
 
+  /**
+   * As string list list.
+   *
+   * @param object the object
+   * @return the list
+   */
   public static List<String> asStringList(Object object) {
     if (object instanceof List) {
       return (List<String>) object;
@@ -124,6 +148,12 @@ public final class SerializeUtil {
     throw new IllegalArgumentException("Unsupported type: " + object.getClass());
   }
 
+  /**
+   * As list list.
+   *
+   * @param object the object
+   * @return the list
+   */
   public static List asList(Object object) {
     if (object instanceof List) {
       return (List) object;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
@@ -133,7 +133,7 @@ public final class SerializeUtil {
   }
 
   /**
-   * As string list list.
+   * As string list.
    *
    * @param object the object
    * @return the list

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtil.java
@@ -149,7 +149,7 @@ public final class SerializeUtil {
   }
 
   /**
-   * As list list.
+   * As list.
    *
    * @param object the object
    * @return the list

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdSerializer.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdSerializer.java
@@ -25,12 +25,13 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidJsonLdException;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
 import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedVerifiablePresentation;
 
+/** The interface Json ld serializer. */
 public interface JsonLdSerializer {
 
   /**
-   * Serlizer a presentation to a Json string
+   * Serializer a presentation to a Json string
    *
-   * @param verifiablePresentation
+   * @param verifiablePresentation the verifiable presentation
    * @return {@link SerializedVerifiablePresentation}
    */
   SerializedVerifiablePresentation serializePresentation(
@@ -39,10 +40,10 @@ public interface JsonLdSerializer {
   /**
    * Deserialize a presentation with options to validate JSON-LD or not.
    *
-   * @param serializedPresentation
-   * @param validateJsonLd
-   * @return VerifiablePresentation
-   * @throws InvalidJsonLdException
+   * @param serializedPresentation the serialized presentation
+   * @param validateJsonLd the validate json ld
+   * @return VerifiablePresentation verifiable presentation
+   * @throws InvalidJsonLdException the invalid json ld exception
    */
   VerifiablePresentation deserializePresentation(
       SerializedVerifiablePresentation serializedPresentation, boolean validateJsonLd)
@@ -51,9 +52,9 @@ public interface JsonLdSerializer {
   /**
    * Deserialize a presentation and validates the JSON-LD.
    *
-   * @param serializedPresentation
-   * @return VerifiablePresentation
-   * @throws InvalidJsonLdException
+   * @param serializedPresentation the serialized presentation
+   * @return VerifiablePresentation verifiable presentation
+   * @throws InvalidJsonLdException the invalid json ld exception
    */
   VerifiablePresentation deserializePresentation(
       SerializedVerifiablePresentation serializedPresentation) throws InvalidJsonLdException;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdSerializerImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdSerializerImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.ssi.lib.serialization.jwt.SerializedVerifiablePresen
 import org.eclipse.tractusx.ssi.lib.validation.JsonLdValidator;
 import org.eclipse.tractusx.ssi.lib.validation.JsonLdValidatorImpl;
 
+/** The type Json ld serializer. */
 public class JsonLdSerializerImpl implements JsonLdSerializer {
 
   @Override

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidator.java
@@ -23,7 +23,14 @@ package org.eclipse.tractusx.ssi.lib.serialization.jsonLd;
 
 import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 
+/** The interface Json ld validator. */
 public interface JsonLdValidator {
 
+  /**
+   * Validate boolean.
+   *
+   * @param jsonLdObject the json ld object
+   * @return the boolean
+   */
   public boolean validate(JsonLdObject jsonLdObject);
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidator.java
@@ -27,7 +27,7 @@ import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 public interface JsonLdValidator {
 
   /**
-   * Validate boolean.
+   * Validate json ld object..
    *
    * @param jsonLdObject the json ld object
    * @return the boolean

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidatorImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jsonLd/JsonLdValidatorImpl.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.eclipse.tractusx.ssi.lib.model.JsonLdObject;
 import org.eclipse.tractusx.ssi.lib.model.RemoteDocumentLoader;
 
+/** The type Json ld validator. */
 public class JsonLdValidatorImpl implements JsonLdValidator {
 
   private static final String UNDEFINED_TERM_URI = "urn:UNDEFINEDTERM";

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactory.java
@@ -27,7 +27,17 @@ import org.eclipse.tractusx.ssi.lib.crypt.IPrivateKey;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 
+/** The interface Serialized jwt presentation factory. */
 public interface SerializedJwtPresentationFactory {
+  /**
+   * Create presentation signed jwt.
+   *
+   * @param issuer the issuer
+   * @param credentials the credentials
+   * @param audience the audience
+   * @param privateKey the private key
+   * @return the signed jwt
+   */
   SignedJWT createPresentation(
       Did issuer, List<VerifiableCredential> credentials, String audience, IPrivateKey privateKey);
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePres
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationType;
 import org.eclipse.tractusx.ssi.lib.serialization.jsonLd.JsonLdSerializer;
 
+/** The type Serialized jwt presentation factory. */
 @RequiredArgsConstructor
 public class SerializedJwtPresentationFactoryImpl implements SerializedJwtPresentationFactory {
 

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedVerifiableCredential.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedVerifiableCredential.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.ssi.lib.serialization.jwt;
 
 import lombok.Value;
 
+/** The type Serialized verifiable credential. */
 @Value
 public class SerializedVerifiableCredential {
   String json;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedVerifiablePresentation.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedVerifiablePresentation.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.ssi.lib.serialization.jwt;
 
 import lombok.Value;
 
+/** The type Serialized verifiable presentation. */
 @Value
 public class SerializedVerifiablePresentation {
   String json;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/VerifiableCredentialSerializer.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/VerifiableCredentialSerializer.java
@@ -29,7 +29,19 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCreden
  * in an information loss, der is not serialization of the same credential possible anymore.
  */
 public interface VerifiableCredentialSerializer {
+  /**
+   * Deserialize verifiable credential.
+   *
+   * @param credentialJson the credential json
+   * @return the verifiable credential
+   */
   VerifiableCredential deserialize(Map<String, Object> credentialJson);
 
+  /**
+   * Serialize string.
+   *
+   * @param credential the credential
+   * @return the string
+   */
   String serialize(VerifiableCredential credential);
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidator.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidator.java
@@ -25,9 +25,22 @@ import org.eclipse.tractusx.ssi.lib.exception.InvalidJsonLdException;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
 
+/** The interface Json ld validator. */
 public interface JsonLdValidator {
 
+  /**
+   * Validate.
+   *
+   * @param verifiablePresentation the verifiable presentation
+   * @throws InvalidJsonLdException the invalid json ld exception
+   */
   void validate(VerifiablePresentation verifiablePresentation) throws InvalidJsonLdException;
 
+  /**
+   * Validate.
+   *
+   * @param verifiableCredential the verifiable credential
+   * @throws InvalidJsonLdException the invalid json ld exception
+   */
   void validate(VerifiableCredential verifiableCredential) throws InvalidJsonLdException;
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidatorImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidatorImpl.java
@@ -37,6 +37,7 @@ import org.eclipse.tractusx.ssi.lib.model.RemoteDocumentLoader;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
 
+/** The type Json ld validator. */
 public class JsonLdValidatorImpl implements JsonLdValidator {
   private static final String UNDEFINED_TERM_URI = "urn:UNDEFINEDTERM";
 

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base58BitcoinTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base58BitcoinTest.java
@@ -26,18 +26,21 @@ import org.eclipse.tractusx.ssi.lib.model.base.Base58Bitcoin;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Base 58 bitcoin test. */
 public class Base58BitcoinTest {
 
   private static final byte[] DECODED =
       "Multibase is awesome! \\o/".getBytes(StandardCharsets.UTF_8);
   private static final String ENCODED = "zYAjKoNbau5KiqmHPmSxYCvn66dA1vLmwbt";
 
+  /** Test encoding. */
   @Test
   public void testEncoding() {
     var multibase = Base58Bitcoin.create(DECODED);
     Assertions.assertEquals(ENCODED, multibase.getEncoded());
   }
 
+  /** Test decoding. */
   @Test
   public void testDecoding() {
     var multibase = Base58Bitcoin.create(ENCODED);

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base64Test.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base64Test.java
@@ -26,18 +26,21 @@ import org.eclipse.tractusx.ssi.lib.model.base.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Base 64 test. */
 public class Base64Test {
 
   private static final byte[] DECODED =
       "Multibase is awesome! \\o/".getBytes(StandardCharsets.UTF_8);
   private static final String ENCODED = "mTXVsdGliYXNlIGlzIGF3ZXNvbWUhIFxvLw";
 
+  /** Test encoding. */
   @Test
   public void testEncoding() {
     var multibase = Base64.create(DECODED);
     Assertions.assertEquals(ENCODED, multibase.getEncoded());
   }
 
+  /** Test decoding. */
   @Test
   public void testDecoding() {
     var multibase = Base64.create(ENCODED);

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base64WithPaddingTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/base/Base64WithPaddingTest.java
@@ -26,18 +26,21 @@ import org.eclipse.tractusx.ssi.lib.model.base.Base64WithPadding;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Base 64 with padding test. */
 public class Base64WithPaddingTest {
 
   private static final byte[] DECODED =
       "Multibase is awesome! \\o/".getBytes(StandardCharsets.UTF_8);
   private static final String ENCODED = "MTXVsdGliYXNlIGlzIGF3ZXNvbWUhIFxvLw==";
 
+  /** Test encoding. */
   @Test
   public void testEncoding() {
     var multibase = Base64WithPadding.create(DECODED);
     Assertions.assertEquals(ENCODED, multibase.getEncoded());
   }
 
+  /** Test decoding. */
   @Test
   public void testDecoding() {
     var multibase = Base64WithPadding.create(ENCODED);

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/cypto/ed21995/ed21559KeyTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/cypto/ed21995/ed21559KeyTest.java
@@ -37,8 +37,14 @@ import org.eclipse.tractusx.ssi.lib.exception.KeyGenerationException;
 import org.eclipse.tractusx.ssi.lib.model.base.EncodeType;
 import org.junit.jupiter.api.Test;
 
+/** The type Ed 21559 key test. */
 public class ed21559KeyTest {
 
+  /**
+   * Test ed 21559 key generation.
+   *
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testED21559KeyGeneration() throws KeyGenerationException {
     IKeyGenerator keyGenerator = new x21559Generator();
@@ -47,6 +53,12 @@ public class ed21559KeyTest {
     assertNotNull(keyPair.getPublicKey());
   }
 
+  /**
+   * Test ed 21559 key serliztion.
+   *
+   * @throws KeyGenerationException the key generation exception
+   * @throws IOException the io exception
+   */
   @Test
   public void testED21559KeySerliztion() throws KeyGenerationException, IOException {
     IKeyGenerator keyGenerator = new x21559Generator();
@@ -61,6 +73,14 @@ public class ed21559KeyTest {
     assertNotNull(keyPair.getPublicKey().asStringForExchange(EncodeType.Base64));
   }
 
+  /**
+   * Test ed 21559 key deserliztion.
+   *
+   * @throws KeyGenerationException the key generation exception
+   * @throws IOException the io exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   */
   @Test
   public void testED21559KeyDeserliztion()
       throws KeyGenerationException, IOException, InvalidePrivateKeyFormat,

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/CompositeDidResolverTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/CompositeDidResolverTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/** The type Composite did resolver test. */
 @ExtendWith(MockitoExtension.class)
 public class CompositeDidResolverTest {
   @Mock private DidResolver resolver1;
@@ -54,12 +55,18 @@ public class CompositeDidResolverTest {
   private static final Did DID =
       new Did(new DidMethod("web"), new DidMethodIdentifier("localhost"), null);
 
+  /** Reset mocks. */
   @BeforeEach
   public void resetMocks() {
     reset(resolver1);
     reset(resolver2);
   }
 
+  /**
+   * Should resolve with one resolver.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveWithOneResolver() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(true);
@@ -69,6 +76,11 @@ public class CompositeDidResolverTest {
     assertEquals(RESOLVED_DID_DOC, resolver.resolve(DID));
   }
 
+  /**
+   * Should resolve with first resolver.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveWithFirstResolver() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(true);
@@ -81,6 +93,11 @@ public class CompositeDidResolverTest {
     verify(resolver2, never()).resolve(any());
   }
 
+  /**
+   * Should resolve with second resolver.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveWithSecondResolver() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(false);
@@ -93,6 +110,11 @@ public class CompositeDidResolverTest {
     verify(resolver1, never()).resolve(any());
   }
 
+  /**
+   * Must not resolve on false.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void mustNotResolveOnFalse() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(false);
@@ -105,6 +127,11 @@ public class CompositeDidResolverTest {
     verify(resolver2, never()).resolve(any());
   }
 
+  /**
+   * Must not resolve on exception.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void mustNotResolveOnException() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(true);
@@ -121,6 +148,11 @@ public class CompositeDidResolverTest {
     verify(resolver2, never()).resolve(any());
   }
 
+  /**
+   * Should construct composite resolver using static method.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldConstructCompositeResolverUsingStaticMethod() throws DidResolverException {
     when(resolver1.isResolvable(any())).thenReturn(true);

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
@@ -41,10 +41,12 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
+/** The type Did uni resolver it. */
 @Testcontainers
 public class DidUniResolverIT {
   private DidUniResolver resolver;
 
+  /** The constant nginx. */
   @Container
   public static NginxContainer<?> nginx =
       new NginxContainer<>("nginx")
@@ -64,6 +66,12 @@ public class DidUniResolverIT {
           .withExposedPorts(8080)
           .waitingFor(new HostPortWaitStrategy());
 
+  /**
+   * Init each.
+   *
+   * @throws MalformedURLException the malformed url exception
+   * @throws URISyntaxException the uri syntax exception
+   */
   @BeforeEach
   public void initEach() throws MalformedURLException, URISyntaxException {
     resolver =
@@ -72,6 +80,11 @@ public class DidUniResolverIT {
             "http://" + uniResolver.getHost() + ":" + uniResolver.getFirstMappedPort());
   }
 
+  /**
+   * Should resolve valid did.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveValidDid() throws DidResolverException {
     Did validDidWeb =

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/AbstractDidWebResolverTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/AbstractDidWebResolverTest.java
@@ -27,23 +27,43 @@ import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethodIdentifier;
 import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 
+/** The type Abstract did web resolver test. */
 public abstract class AbstractDidWebResolverTest {
+  /** The Did web doc. */
   protected DidDocument didWebDoc;
+  /** The Valid did web. */
   protected Did validDidWeb;
+  /** The Resolver. */
   protected DidWebResolver resolver;
+  /** The constant VALID_DID_KEY. */
   protected static Did VALID_DID_KEY =
       new Did(
           new DidMethod("key"),
           new DidMethodIdentifier("z6Mkfriq1MqLBoPWecGoDLjguo1sB9brj6wT3qZ5BxkKpuP6"),
           null);
 
+  /**
+   * Instantiates a new Abstract did web resolver test.
+   *
+   * @param validDidWeb the valid did web
+   */
   public AbstractDidWebResolverTest(Did validDidWeb) {
     this.validDidWeb = validDidWeb;
     this.didWebDoc = new DidDocument(TestResourceUtil.getPublishedDidDocument());
     System.out.println("Testing with DID: " + validDidWeb.toString());
   }
 
+  /**
+   * Should resolve valid web did.
+   *
+   * @throws Exception the exception
+   */
   public abstract void shouldResolveValidWebDid() throws Exception;
 
+  /**
+   * Should not resolve non web did.
+   *
+   * @throws Exception the exception
+   */
   public abstract void shouldNotResolveNonWebDid() throws Exception;
 }

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebFactoryTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebFactoryTest.java
@@ -26,8 +26,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+/** The type Did web factory test. */
 public class DidWebFactoryTest {
 
+  /**
+   * Test create did from hostname.
+   *
+   * @param hostname the hostname
+   * @param expectedDid the expected did
+   */
   @ParameterizedTest
   @CsvSource({
     "localhost, did:web:localhost",
@@ -40,6 +47,13 @@ public class DidWebFactoryTest {
     Assertions.assertEquals(expectedDid, did.toString());
   }
 
+  /**
+   * Test create did from hostname and path.
+   *
+   * @param hostname the hostname
+   * @param path the path
+   * @param expectedDid the expected did
+   */
   @ParameterizedTest
   @CsvSource({
     "some-host, path, did:web:some-host:path",

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolverIT.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolverIT.java
@@ -40,11 +40,13 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.MountableFile;
 
+/** The type Did web resolver it. */
 @Testcontainers
 public class DidWebResolverIT {
   private DidWebResolver resolver;
   private DidWebResolver httpsResolver;
 
+  /** The constant nginx. */
   @Container
   public static NginxContainer<?> nginx =
       new NginxContainer<>("nginx")
@@ -53,12 +55,18 @@ public class DidWebResolverIT {
               "/usr/share/nginx/html")
           .waitingFor(new HttpWaitStrategy());
 
+  /** Init each. */
   @BeforeEach
   public void initEach() {
     resolver = new DidWebResolver(HttpClient.newHttpClient(), new DidWebParser(), false);
     httpsResolver = new DidWebResolver(HttpClient.newHttpClient(), new DidWebParser(), true);
   }
 
+  /**
+   * Should resolve valid web did.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveValidWebDid() throws DidResolverException {
     Did validDidWeb =
@@ -71,6 +79,11 @@ public class DidWebResolverIT {
     assertEquals(new DidDocument(TestResourceUtil.getPublishedDidDocument()), actualDidDoc);
   }
 
+  /**
+   * Should resolve valid external web did.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldResolveValidExternalWebDid() throws DidResolverException {
     final String didIdentifier = "did.actor:alice";

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolverTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebResolverTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/** The type Did web resolver test. */
 @ExtendWith(MockitoExtension.class)
 public class DidWebResolverTest {
 
@@ -56,11 +57,20 @@ public class DidWebResolverTest {
 
   private DidWebResolver resolver;
 
+  /** Init each. */
   @BeforeEach
   public void initEach() {
     resolver = new DidWebResolver(httpClient, parser, false);
   }
 
+  /**
+   * Should resolve valid web did.
+   *
+   * @throws DidResolverException the did resolver exception
+   * @throws IOException the io exception
+   * @throws InterruptedException the interrupted exception
+   * @throws URISyntaxException the uri syntax exception
+   */
   @Test
   public void shouldResolveValidWebDid()
       throws DidResolverException, IOException, InterruptedException, URISyntaxException {
@@ -75,6 +85,11 @@ public class DidWebResolverTest {
     assertEquals(new DidDocument(TestResourceUtil.getPublishedDidDocument()), actualDidDoc);
   }
 
+  /**
+   * Should not resolve non web did.
+   *
+   * @throws DidResolverException the did resolver exception
+   */
   @Test
   public void shouldNotResolveNonWebDid() throws DidResolverException {
     Did validDidKey =

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/util/DidWebParserTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/web/util/DidWebParserTest.java
@@ -29,10 +29,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+/** The type Did web parser test. */
 public class DidWebParserTest {
 
   private final DidWebParser parser = new DidWebParser();
 
+  /**
+   * Test resolve uri from did.
+   *
+   * @param methodIdentifier the method identifier
+   * @param expectedUri the expected uri
+   */
   @ParameterizedTest
   @CsvSource({
     "localhost, https://localhost/.well-known/did.json",

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidDocumentTest.java
@@ -29,10 +29,12 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Did document test. */
 public class DidDocumentTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /** Can create did document. */
   @Test
   public void canCreateDidDocument() {
     final List<Map<String, Object>> documents = TestResourceUtil.getAllDidDocuments();
@@ -42,6 +44,7 @@ public class DidDocumentTest {
     }
   }
 
+  /** Can serialize did document. */
   @Test
   @SneakyThrows
   public void canSerializeDidDocument() {
@@ -54,6 +57,7 @@ public class DidDocumentTest {
     }
   }
 
+  /** Can deserialize did document. */
   @Test
   @SneakyThrows
   public void canDeserializeDidDocument() {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidTest.java
@@ -24,7 +24,9 @@ package org.eclipse.tractusx.ssi.lib.model.did;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Did test. */
 public class DidTest {
+  /** Test did equals. */
   @Test
   public void testDidEquals() {
 

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/JsonWebKey2020BuilderTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/JsonWebKey2020BuilderTest.java
@@ -38,8 +38,10 @@ import org.eclipse.tractusx.ssi.lib.crypt.x21559.x21559PublicKey;
 import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.junit.jupiter.api.Test;
 
+/** The type Json web key 2020 builder test. */
 class JsonWebKey2020BuilderTest {
 
+  /** Test json web key 2020 verification method. */
   @SneakyThrows
   @Test
   public void testJsonWebKey2020VerificationMethod() {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialStatusTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialStatusTest.java
@@ -36,8 +36,14 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Verifiable credential status test. */
 class VerifiableCredentialStatusTest {
 
+  /**
+   * Test credential status serialization.
+   *
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   void testCredentialStatusSerialization() throws JsonProcessingException {
     // test valid parsing from json object

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/credential/VerifiableCredentialTest.java
@@ -25,8 +25,10 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Verifiable credential test. */
 public class VerifiableCredentialTest {
 
+  /** Equals success. */
   @Test
   public void equalsSuccess() {
     final VerifiableCredential vc1 = TestResourceUtil.getAlumniVerifiableCredential();
@@ -34,6 +36,7 @@ public class VerifiableCredentialTest {
     Assertions.assertEquals(vc1.toString(), vc2.toString());
   }
 
+  /** Equals failure. */
   @Test
   public void equalsFailure() {
     final VerifiableCredential vc1 = TestResourceUtil.getBPNVerifiableCredential();
@@ -42,6 +45,7 @@ public class VerifiableCredentialTest {
     Assertions.assertNotEquals(vc1, vc2);
   }
 
+  /** Credential id must be valid uri. */
   @Test
   public void credentialIdMustBeValidURI() {
     final VerifiableCredential vc = TestResourceUtil.getAlumniVerifiableCredential();

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/verifiable/presentation/VerifiablePresentationTest.java
@@ -25,8 +25,10 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Verifiable presentation test. */
 public class VerifiablePresentationTest {
 
+  /** Equals success. */
   @Test
   public void equalsSuccess() {
     final VerifiablePresentation vp1 = TestResourceUtil.getAlumniVerifiablePresentation();
@@ -35,6 +37,7 @@ public class VerifiablePresentationTest {
     Assertions.assertEquals(vp1.toString(), vp2.toString());
   }
 
+  /** Equals failure. */
   @Test
   public void equalsFailure() {
     final VerifiablePresentation vp1 = TestResourceUtil.getAlumniVerifiablePresentation();

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofValidationComponentTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataProofValidationComponentTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/** The type Linked data proof validation component test. */
 public class LinkedDataProofValidationComponentTest {
 
   private LinkedDataProofValidation linkedDataProofValidation;
@@ -51,12 +52,21 @@ public class LinkedDataProofValidationComponentTest {
   private TestIdentity credentialIssuer;
   private TestDidResolver didResolver;
 
+  /** Sets . */
   @BeforeEach
   public void setup() {
     SsiLibrary.initialize();
     this.didResolver = new TestDidResolver();
   }
 
+  /**
+   * Test vc proof failure on manipulated credential.
+   *
+   * @throws IOException the io exception
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testVCProofFailureOnManipulatedCredential()
       throws IOException, UnsupportedSignatureTypeException, InvalidePrivateKeyFormat,
@@ -95,6 +105,14 @@ public class LinkedDataProofValidationComponentTest {
     Assertions.assertFalse(isOk);
   }
 
+  /**
+   * Test vc ed 21559 proof generation and verification.
+   *
+   * @throws IOException the io exception
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testVCEd21559ProofGenerationAndVerification()
       throws IOException, UnsupportedSignatureTypeException, InvalidePrivateKeyFormat,
@@ -127,6 +145,14 @@ public class LinkedDataProofValidationComponentTest {
     Assertions.assertTrue(isOk);
   }
 
+  /**
+   * Test vcjws proof generation and verification.
+   *
+   * @throws IOException the io exception
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testVCJWSProofGenerationAndVerification()
       throws IOException, UnsupportedSignatureTypeException, InvalidePrivateKeyFormat,
@@ -160,6 +186,14 @@ public class LinkedDataProofValidationComponentTest {
     Assertions.assertTrue(isOk);
   }
 
+  /**
+   * Test vp ed 21559 proof generation and verification.
+   *
+   * @throws IOException the io exception
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testVPEd21559ProofGenerationAndVerification()
       throws IOException, UnsupportedSignatureTypeException, InvalidePrivateKeyFormat,
@@ -201,6 +235,14 @@ public class LinkedDataProofValidationComponentTest {
     Assertions.assertTrue(isOk);
   }
 
+  /**
+   * Test vpjws proof generation and verification.
+   *
+   * @throws IOException the io exception
+   * @throws UnsupportedSignatureTypeException the unsupported signature type exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testVPJWSProofGenerationAndVerification()
       throws IOException, UnsupportedSignatureTypeException, InvalidePrivateKeyFormat,

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataTransformerTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/proof/LinkedDataTransformerTest.java
@@ -35,10 +35,12 @@ import org.eclipse.tractusx.ssi.lib.proof.transform.LinkedDataTransformer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Linked data transformer test. */
 public class LinkedDataTransformerTest {
 
   private final LinkedDataTransformer linkedDataTransformer = new LinkedDataTransformer();
 
+  /** Test linked data transformer. */
   @Test
   @SneakyThrows
   public void testLinkedDataTransformer() {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/proof/SignAndVerifyTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/proof/SignAndVerifyTest.java
@@ -38,8 +38,17 @@ import org.eclipse.tractusx.ssi.lib.util.identity.TestIdentityFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Sign and verify test. */
 public class SignAndVerifyTest {
 
+  /**
+   * Test sign and verify ed 201559.
+   *
+   * @throws IOException the io exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testSignAndVerify_ED201559()
       throws IOException, InvalidePrivateKeyFormat, InvalidePublicKeyFormat,
@@ -61,6 +70,16 @@ public class SignAndVerifyTest {
     Assertions.assertTrue(isSigned);
   }
 
+  /**
+   * Test sign and verify jws.
+   *
+   * @throws IOException the io exception
+   * @throws JOSEException the jose exception
+   * @throws NoSuchAlgorithmException the no such algorithm exception
+   * @throws InvalidePrivateKeyFormat the invalide private key format
+   * @throws InvalidePublicKeyFormat the invalide public key format
+   * @throws KeyGenerationException the key generation exception
+   */
   @Test
   public void testSignAndVerify_JWS()
       throws IOException, JOSEException, NoSuchAlgorithmException, InvalidePrivateKeyFormat,

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/proof/proof/LinkedDataTransformerTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/proof/proof/LinkedDataTransformerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+/** The type Linked data transformer test. */
 public class LinkedDataTransformerTest {
 
   private static final String SummaryVerifiableCredential =
@@ -70,6 +71,7 @@ public class LinkedDataTransformerTest {
 
   private final LinkedDataTransformer transformer = new LinkedDataTransformer();
 
+  /** Test two transformations equal. */
   @Test
   public void testTwoTransformationsEqual() {
     final VerifiableCredential credential1 = deserializeCredential(SummaryVerifiableCredential);
@@ -79,6 +81,12 @@ public class LinkedDataTransformerTest {
     Assertions.assertEquals(data1, data2);
   }
 
+  /**
+   * Test two transformation difference.
+   *
+   * @param original the original
+   * @param replace the replace
+   */
   @ParameterizedTest()
   @CsvSource(
       value = {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtilTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/SerializeUtilTest.java
@@ -39,8 +39,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+/** The type Serialize util test. */
 public class SerializeUtilTest {
 
+  /** Should serialize vc context first. */
   @Test
   public void shouldSerializeVcContextFirst() {
     VerifiableCredential vc = TestResourceUtil.getAlumniVerifiableCredential();
@@ -50,6 +52,7 @@ public class SerializeUtilTest {
         serializedVc.startsWith("{\"@context\":["), "Serialized VC should start with @context");
   }
 
+  /** Should serialize vp context first. */
   @Test
   public void shouldSerializeVpContextFirst() {
     VerifiablePresentation vp = TestResourceUtil.getAlumniVerifiablePresentation();
@@ -59,6 +62,11 @@ public class SerializeUtilTest {
         serializedVc.startsWith("{\"@context\":["), "Serialized VP should start with @context");
   }
 
+  /**
+   * Test vc json property order.
+   *
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   @DisplayName("Test property order in json string for VC")
   void testVCJsonPropertyOrder() throws JsonProcessingException {
@@ -84,6 +92,11 @@ public class SerializeUtilTest {
     }
   }
 
+  /**
+   * Test did document json property order.
+   *
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   @DisplayName("Test property order in json string for did document")
   void testDidDocumentJsonPropertyOrder() throws JsonProcessingException {
@@ -109,6 +122,11 @@ public class SerializeUtilTest {
     }
   }
 
+  /**
+   * Test vp json property order.
+   *
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   @DisplayName("Test property order in json string for VP")
   void testVPJsonPropertyOrder() throws JsonProcessingException {
@@ -134,6 +152,11 @@ public class SerializeUtilTest {
     }
   }
 
+  /**
+   * Test status list json property order.
+   *
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   @DisplayName("Test property order in json string for status list")
   void testStatusListJsonPropertyOrder() throws JsonProcessingException {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jsonld/DanubeTechMapperTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jsonld/DanubeTechMapperTest.java
@@ -21,6 +21,7 @@
 
 package org.eclipse.tractusx.ssi.lib.serialization.jsonld;
 
+/** The type Danube tech mapper test. */
 public class DanubeTechMapperTest {
 
   // @SneakyThrows

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImplTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImplTest.java
@@ -44,6 +44,7 @@ import org.eclipse.tractusx.ssi.lib.util.vc.TestVerifiableFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Serialized jwt presentation factory impl test. */
 class SerializedJwtPresentationFactoryImplTest {
 
   private LinkedDataProofGenerator linkedDataProofGenerator;
@@ -53,6 +54,7 @@ class SerializedJwtPresentationFactoryImplTest {
 
   private SignedJwtVerifier jwtVerifier;
 
+  /** Test jwt serialization. */
   @SneakyThrows
   @Test
   public void testJwtSerialization() {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/TestResourceUtil.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/TestResourceUtil.java
@@ -36,6 +36,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.Ed25519VerificationMethod;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
 
+/** The type Test resource util. */
 public class TestResourceUtil {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -50,23 +51,49 @@ public class TestResourceUtil {
       "verifiable-presentation/alumni-presentation.json";
   private static String VERIFIABLE_CREDENTIAL_BPN = "verifiable-credential/bpn-credential.json";
 
+  /**
+   * Gets all did documents.
+   *
+   * @return the all did documents
+   */
   public static List<Map<String, Object>> getAllDidDocuments() {
     return Arrays.asList(
         readJsonResource(DID_DOCUMENT_ED25519), readJsonResource(DID_DOCUMENT_ED25519_BPN));
   }
 
+  /**
+   * Gets alumni verifiable credential.
+   *
+   * @return the alumni verifiable credential
+   */
   public static VerifiableCredential getAlumniVerifiableCredential() {
     return new VerifiableCredential(readJsonResource(VERIFIABLE_CREDENTIAL_ALUMNI));
   }
 
+  /**
+   * Gets alumni verifiable presentation.
+   *
+   * @return the alumni verifiable presentation
+   */
   public static VerifiablePresentation getAlumniVerifiablePresentation() {
     return new VerifiablePresentation(readJsonResource(VERIFIABLE_PRESENTATION_ALUMNI));
   }
 
+  /**
+   * Gets bpn verifiable credential.
+   *
+   * @return the bpn verifiable credential
+   */
   public static VerifiableCredential getBPNVerifiableCredential() {
     return new VerifiableCredential(readJsonResource(VERIFIABLE_CREDENTIAL_BPN));
   }
 
+  /**
+   * Gets did document.
+   *
+   * @param verificationKeyType the verification key type
+   * @return the did document
+   */
   public static Map<String, Object> getDidDocument(String verificationKeyType) {
     if (Ed25519VerificationMethod.DEFAULT_TYPE.equals(verificationKeyType)) {
       return readJsonResource(DID_DOCUMENT_ED25519);
@@ -75,14 +102,29 @@ public class TestResourceUtil {
     throw new IllegalArgumentException("Unsupported verification key type: " + verificationKeyType);
   }
 
+  /**
+   * Gets bpn did document.
+   *
+   * @return the bpn did document
+   */
   public static Map<String, Object> getBPNDidDocument() {
     return readJsonResource(DID_DOCUMENT_ED25519_BPN);
   }
 
+  /**
+   * Gets published did document.
+   *
+   * @return the published did document
+   */
   public static Map<String, Object> getPublishedDidDocument() {
     return readJsonResource(DID_DOCUMENT_PUBLISHED);
   }
 
+  /**
+   * Gets published did document as string.
+   *
+   * @return the published did document as string
+   */
   public static String getPublishedDidDocumentAsString() {
     try {
       return new String(
@@ -92,14 +134,29 @@ public class TestResourceUtil {
     }
   }
 
+  /**
+   * Get public key ed 25519 byte [ ].
+   *
+   * @return the byte [ ]
+   */
   public static byte[] getPublicKeyEd25519() {
     return readPemResource(PUBLIC_KEY_ED25519);
   }
 
+  /**
+   * Get private key ed 25519 byte [ ].
+   *
+   * @return the byte [ ]
+   */
   public static byte[] getPrivateKeyEd25519() {
     return readPemResource(PRIVATE_KEY_ED25519);
   }
 
+  /**
+   * Gets public key ed 25519 as string.
+   *
+   * @return the public key ed 25519 as string
+   */
   public static String getPublicKeyEd25519AsString() {
     try {
       return new String(
@@ -109,6 +166,11 @@ public class TestResourceUtil {
     }
   }
 
+  /**
+   * Gets private key ed 25519 as string.
+   *
+   * @return the private key ed 25519 as string
+   */
   public static String getPrivateKeyEd25519AsString() {
     try {
       return new String(

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidDocumentResolver.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidDocumentResolver.java
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 
+/** The type Test did document resolver. */
 @Deprecated
 /** Remove when {@code DidDocumentResolver} is removed. */
 public class TestDidDocumentResolver implements DidDocumentResolver {
@@ -59,10 +60,20 @@ public class TestDidDocumentResolver implements DidDocumentResolver {
     return documents.get(didWithoutFragment);
   }
 
+  /**
+   * Register.
+   *
+   * @param testIdentity the test identity
+   */
   public void register(TestIdentity testIdentity) {
     documents.put(testIdentity.getDid(), testIdentity.getDidDocument());
   }
 
+  /**
+   * With registry did document resolver registry.
+   *
+   * @return the did document resolver registry
+   */
   public DidDocumentResolverRegistry withRegistry() {
     final DidDocumentResolverRegistry registry = new DidDocumentResolverRegistryImpl();
     registry.register(this);

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidFactory.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidFactory.java
@@ -26,9 +26,16 @@ import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.DidMethodIdentifier;
 
+/** The type Test did factory. */
 public class TestDidFactory {
+  /** The constant DID_METHOD. */
   public static final DidMethod DID_METHOD = new DidMethod("test");
 
+  /**
+   * Create random did.
+   *
+   * @return the did
+   */
   public static Did createRandom() {
     return new Did(DID_METHOD, new DidMethodIdentifier(UUID.randomUUID().toString()), null);
   }

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidResolver.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestDidResolver.java
@@ -28,6 +28,7 @@ import org.eclipse.tractusx.ssi.lib.did.resolver.DidResolver;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 
+/** The type Test did resolver. */
 public class TestDidResolver implements DidResolver {
   private final Map<Did, DidDocument> documents = new HashMap<>();
 
@@ -53,6 +54,11 @@ public class TestDidResolver implements DidResolver {
     return documents.get(didWithoutFragment);
   }
 
+  /**
+   * Register.
+   *
+   * @param testIdentity the test identity
+   */
   public void register(TestIdentity testIdentity) {
     documents.put(testIdentity.getDid(), testIdentity.getDidDocument());
   }

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentity.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentity.java
@@ -27,6 +27,7 @@ import org.eclipse.tractusx.ssi.lib.crypt.IPublicKey;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 
+/** The type Test identity. */
 @Value
 public class TestIdentity {
   Did did;

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentityFactory.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentityFactory.java
@@ -41,8 +41,16 @@ import org.eclipse.tractusx.ssi.lib.model.did.Ed25519VerificationMethodBuilder;
 import org.eclipse.tractusx.ssi.lib.model.did.JWKVerificationMethod;
 import org.eclipse.tractusx.ssi.lib.model.did.JWKVerificationMethodBuilder;
 
+/** The type Test identity factory. */
 public class TestIdentityFactory {
 
+  /**
+   * New identity with ed 25519 keys test identity.
+   *
+   * @return the test identity
+   * @throws IOException the io exception
+   * @throws KeyGenerationException the key generation exception
+   */
   public static TestIdentity newIdentityWithED25519Keys()
       throws IOException, KeyGenerationException {
 

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentityTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/identity/TestIdentityTest.java
@@ -31,8 +31,10 @@ import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Test identity test. */
 public class TestIdentityTest {
 
+  /** Test public private key. */
   @Test
   @SneakyThrows
   public void testPublicPrivateKey() {

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/util/vc/TestVerifiableFactory.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/util/vc/TestVerifiableFactory.java
@@ -36,6 +36,7 @@ import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePres
 import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationType;
 import org.eclipse.tractusx.ssi.lib.util.identity.TestIdentity;
 
+/** The type Test verifiable factory. */
 public class TestVerifiableFactory {
   static List<URI> contextList =
       List.of(
@@ -45,6 +46,13 @@ public class TestVerifiableFactory {
           URI.create("https://w3id.org/security/suites/jws-2020/v1"),
           URI.create("https://w3id.org/security/suites/ed25519-2020/v1"));
 
+  /**
+   * Create verifiable credential verifiable credential.
+   *
+   * @param issuer the issuer
+   * @param proof the proof
+   * @return the verifiable credential
+   */
   @SneakyThrows
   public static VerifiableCredential createVerifiableCredential(TestIdentity issuer, Proof proof) {
     final VerifiableCredentialBuilder verifiableCredentialBuilder =
@@ -67,6 +75,14 @@ public class TestVerifiableFactory {
         .build();
   }
 
+  /**
+   * Create verifiable presentation verifiable presentation.
+   *
+   * @param issuer the issuer
+   * @param vcs the vcs
+   * @param proof the proof
+   * @return the verifiable presentation
+   */
   @SneakyThrows
   public static VerifiablePresentation createVerifiablePresentation(
       TestIdentity issuer, List<VerifiableCredential> vcs, Proof proof) {
@@ -82,6 +98,13 @@ public class TestVerifiableFactory {
         .build();
   }
 
+  /**
+   * Attach proof verifiable credential.
+   *
+   * @param verifiableCredential the verifiable credential
+   * @param proof the proof
+   * @return the verifiable credential
+   */
   public static VerifiableCredential attachProof(
       VerifiableCredential verifiableCredential, Proof proof) {
     VerifiableCredentialBuilder verifiableCredentialBuilder = new VerifiableCredentialBuilder();
@@ -99,6 +122,13 @@ public class TestVerifiableFactory {
         .build();
   }
 
+  /**
+   * Attach proof verifiable presentation.
+   *
+   * @param verifiablePresentation the verifiable presentation
+   * @param proof the proof
+   * @return the verifiable presentation
+   */
   public static VerifiablePresentation attachProof(
       VerifiablePresentation verifiablePresentation, Proof proof) {
 

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidatorTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/validation/JsonLdValidatorTest.java
@@ -29,14 +29,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/** The type Json ld validator test. */
 public class JsonLdValidatorTest {
   private JsonLdValidator validator;
 
+  /** Sets up. */
   @BeforeEach
   public void setUp() {
     validator = new JsonLdValidatorImpl();
   }
 
+  /** Validate test success. */
   @Test
   public void validateTestSuccess() {
     final VerifiableCredential toTest = loadValidjsonLDObject();

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiableCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiableCredentialTest.java
@@ -32,10 +32,17 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Verifiable credential test. */
 public class VerifiableCredentialTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /**
+   * Can serialize vc.
+   *
+   * @throws JsonMappingException the json mapping exception
+   * @throws JsonProcessingException the json processing exception
+   */
   @Test
   @SneakyThrows
   public void canSerializeVC() throws JsonMappingException, JsonProcessingException {
@@ -47,6 +54,7 @@ public class VerifiableCredentialTest {
         mapFromJson.get(VerifiableCredential.ISSUER), vp.get(VerifiableCredential.ISSUER));
   }
 
+  /** Should load cached context. */
   @Test
   public void shouldLoadCachedContext() {
     var vcFromMap = TestResourceUtil.getAlumniVerifiableCredential();

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/verifiable/VerifiablePresentationTest.java
@@ -29,10 +29,12 @@ import org.eclipse.tractusx.ssi.lib.util.TestResourceUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+/** The type Verifiable presentation test. */
 public class VerifiablePresentationTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /** Can serialize vp. */
   @Test
   @SneakyThrows
   public void canSerializeVP() {
@@ -45,6 +47,7 @@ public class VerifiablePresentationTest {
         vp.get(VerifiablePresentation.VERIFIABLE_CREDENTIAL));
   }
 
+  /** Can serialize v pwith credential not as list. */
   @Test
   @SneakyThrows
   public void canSerializeVPwithCredentialNotAsList() {


### PR DESCRIPTION
## Description
Basic Java doc added with Java doc maven plugin

It will create a javadoc.jar file with `mvn install` command

To verify Java doc run `./mvnw javadoc:javadoc`

Java dock verification was added with compile goal, which means if there is any issue in Java doc then the code will not compile.

Closes #19 