### PR TITLE
chore: add metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "SSI-agent-lib"
+leadingRepository: "https://github.com/eclipse-tractusx/SSI-agent-lib"
+repositories:
+  - name: "SSI-agent-lib"
+    usage: "Implementation of Self-Sovereign Identity solution"
+    url: "https://github.com/eclipse-tractusx/SSI-agent-lib" 


### PR DESCRIPTION
PR to add .tractusx metadata file required as per https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5.