### PR TITLE
Fix: Excluded conflicting dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@ SPDX-License-Identifier: Apache-2.0
             <groupId>io.setl</groupId>
             <artifactId>rdf-urdna</artifactId>
             <version>1.2</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.apicatalog</groupId>
+                <artifactId>titanium-json-ld-jre8</artifactId>
+              </exclusion>
+            </exclusions>			
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/jakarta.json/jakarta.json-api -->


### PR DESCRIPTION
## Description
Fixes #37 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
