### PR TITLE
fix: add timeout for did web resolver

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebDocumentResolver.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/did/web/DidWebDocumentResolver.java
@@ -26,6 +26,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.tractusx.ssi.lib.did.web.util.Constants;
@@ -40,9 +41,20 @@ import org.eclipse.tractusx.ssi.lib.resolver.DidDocumentResolver;
 @RequiredArgsConstructor
 public class DidWebDocumentResolver implements DidDocumentResolver {
 
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+
   private final HttpClient client;
   private final DidWebParser parser;
   private final boolean enforceHttps;
+  private final Duration timeout;
+
+  public DidWebDocumentResolver(HttpClient client, DidWebParser parser) {
+    this(client, parser, true, DEFAULT_TIMEOUT);
+  }
+
+  public DidWebDocumentResolver(HttpClient client, DidWebParser parser, boolean enforceHttps) {
+    this(client, parser, enforceHttps, DEFAULT_TIMEOUT);
+  }
 
   @Override
   public DidMethod getSupportedMethod() {
@@ -57,7 +69,7 @@ public class DidWebDocumentResolver implements DidDocumentResolver {
 
     final URI uri = parser.parse(did, enforceHttps);
 
-    final HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+    final HttpRequest request = HttpRequest.newBuilder().uri(uri).timeout(timeout).GET().build();
 
     try {
       final HttpResponse<String> response =

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/lib/did/web/DidWebDocumentResolverTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/lib/did/web/DidWebDocumentResolverTest.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.ssi.lib.lib.did.web;
+
+import java.net.ServerSocket;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import lombok.SneakyThrows;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebDocumentResolver;
+import org.eclipse.tractusx.ssi.lib.did.web.util.DidWebParser;
+import org.eclipse.tractusx.ssi.lib.model.did.Did;
+import org.eclipse.tractusx.ssi.lib.model.did.DidParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DidWebDocumentResolverTest {
+
+  @Test
+  @SneakyThrows
+  // When the MIW tries to resolve a DID document that is not protected by TLS, but the DID resolve
+  // is configured to
+  // enforce HTTPS, the MIW will hang without timeout.
+  // This test is to ensure that the MIW does not hang anymore when trying to resolve a DID document
+  // that is not protected by TLS.
+  public void testTimeout() {
+
+    final HttpClient httpClient = HttpClient.newHttpClient();
+    final DidWebParser didParser = new DidWebParser();
+    final boolean enforceHttps = true;
+    final Duration timeout = Duration.ofMillis(100);
+    final DidWebDocumentResolver didWebDocumentResolver =
+        new DidWebDocumentResolver(httpClient, didParser, enforceHttps, timeout);
+
+    // open a local port to create an endpoint that is not protected by TLS
+    try (var ss = new ServerSocket(0)) {
+      final int port = ss.getLocalPort();
+      final Did did = DidParser.parse("did:web:localhost%3A" + port);
+      Assertions.assertThrows(RuntimeException.class, () -> didWebDocumentResolver.resolve(did));
+    }
+  }
+}


### PR DESCRIPTION
## Description
When the MIW tries to resolve a DID document that is not protected by TLS, but the DID resolver is configured to enforce HTTPS, the MIW will hang without timeout.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
