### PR TITLE
chore: add skip section to tractusx metadata file

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -3,4 +3,8 @@ leadingRepository: "https://github.com/eclipse-tractusx/SSI-agent-lib"
 repositories:
   - name: "SSI-agent-lib"
     usage: "Implementation of Self-Sovereign Identity solution"
-    url: "https://github.com/eclipse-tractusx/SSI-agent-lib" 
+    url: "https://github.com/eclipse-tractusx/SSI-agent-lib"
+skipReleaseChecks:
+  # Skip TRG 4.02 aligned base images
+  alignedBaseImage:
+    - "docs/pandoc.Dockerfile"


### PR DESCRIPTION
## Description
This will add an exclude for the pandoc Dockerfile during base image scans.
Closes #46 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
