### PR TITLE
ci: add maven publish workflow

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -44,6 +44,14 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      # consider configuring git user
+
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        with:
+          gpg_private_key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+
       - name: Publish to Maven
         env:
           # used in settings.xml

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -30,6 +30,11 @@ on:
         description: The development version to assign after the release
         required: true
         type: string
+      auto_release:
+        description: A switch for automatic release after closing the staging repository
+        required: false
+        type: boolean
+        default: false
   # only committers can trigger this
 jobs:
   publish-maven:
@@ -57,6 +62,7 @@ jobs:
           # used in settings.xml
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          AUTO_RELEASE_AFTER_CLOSE: ${{ inputs.auto_release }}
         # command summary
         # -B/--batch-mode: only display progress and errors
         # -U: update snapshot-releases

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -1,0 +1,76 @@
+################################################################################
+# Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+---
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: The version you want to release
+        required: true
+        type: string
+      developmentVersion:
+        description: The development version to assign after the release
+        required: true
+        type: string
+  # only committers can trigger this
+jobs:
+  publish-maven:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Publish to Maven
+        env:
+          # used in settings.xml
+          MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+        # command summary
+        # -B/--batch-mode: only display progress and errors
+        # -U: update snapshot-releases
+        # -Pci-cd: apply the ci-cd profile (in pom.xml)
+        # release:prepare (comes from maven-release-plugin)
+        # release:perform (comes from maven-release-plugin)
+        # javadoc:jar: checks documentation strings
+        # source:jar: creates a <lib>-<version>-source.jar
+        # -s settings.xml: use custom settings file
+        # -D gpg.passphrase: a system property used by the build process for signing
+        # -D releaseVeresion: set the version you're releasing (will also tag using this)
+        # -D developmentVersion: set the next dev version
+        run: |-
+          echo "Publishing using version: ${{ inputs.version }}"
+          ./mvnw -B -U \
+            -Pci-cd \
+            release:prepare \
+            release:perform \
+            javadoc:jar \
+            source:jar \
+            -s settings.xml \
+            -D gpg.passphrase=${{ secrets.ORG_GPG_PASSPHRASE }} \
+            -D releaseVersion=${{ inputs.releaseVersion }} \
+            -D developmentVersion=${{ inputs.developmentVersion }} \
+            deploy

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -49,17 +49,15 @@ jobs:
           java-version: 17
           distribution: temurin
 
-      # consider configuring git user
-
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v5.0.0
         with:
           gpg_private_key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
 
+        # Environment variables used in settings.xml and pom.xml
       - name: Publish to Maven
         env:
-          # used in settings.xml
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           AUTO_RELEASE_AFTER_CLOSE: ${{ inputs.auto_release }}
@@ -73,7 +71,7 @@ jobs:
         # source:jar: creates a <lib>-<version>-source.jar
         # -s settings.xml: use custom settings file
         # -D gpg.passphrase: a system property used by the build process for signing
-        # -D releaseVeresion: set the version you're releasing (will also tag using this)
+        # -D releaseVersion: set the version you're releasing (will also tag using this)
         # -D developmentVersion: set the next dev version
         run: |-
           echo "Publishing using version: ${{ inputs.version }}"
@@ -88,3 +86,21 @@ jobs:
             -D releaseVersion=${{ inputs.releaseVersion }} \
             -D developmentVersion=${{ inputs.developmentVersion }} \
             deploy
+
+        # artifact_name is cx-ssi-lib and the version should be the *-SNAPSHOT
+        # In the next step we'll use the releaseVersion to finalize the upload
+      - name: Get generated artifact name
+        run: |-
+          echo "artifact_name=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)" >> "$GITHUB_ENV"
+          echo "artifact_version=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_ENV"
+
+        # Use the generated name to supply the input 'path' for the upload,
+        # but upload the final
+        # Example:
+        #   input: cx-ssi-lib-0.0.1-SNAPSHOT.jar
+        #   output: cx-ssi-lib-0.0.1.jar
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.artifact_name }}-${{ inputs.releaseVersion }}
+          path: ./target/${{ env.artifact_name }}-${{ env.artifact_version }}.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Maven Publish Workflow using a manual trigger
 - JSON-LD validation is now performed during linked data validation.
 - Caching for remote resources has been implemented, with fixed duration of 1 day.
 - Add INSTALL.md instructions including Maven and Gradle setup.

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -35,7 +35,7 @@ maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.70, MIT, approved, #1712
-maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.5, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.5, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.3, EPL-2.0, approved, ee4j.parsson

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.ssi</groupId>
     <artifactId>cx-ssi-lib</artifactId>
-    <version>0.0.16</version>
+    <version>0.0.17-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <!-- required when publishing to Maven Central -->

--- a/pom.xml
+++ b/pom.xml
@@ -450,23 +450,6 @@ SPDX-License-Identifier: Apache-2.0
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <!-- Eclipse DataSpace Components "Releases" -->
-        <repository>
-            <id>sonatype-snapshots</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <!-- IDS Information Model. Dependency of Eclipse DataSpace Components -->
-        <repository>
-            <id>fraunhofer-iais-eis</id>
-            <name>Fraunhofer IAIS</name>
-            <url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,44 @@ SPDX-License-Identifier: Apache-2.0
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.ssi</groupId>
+    <artifactId>cx-ssi-lib</artifactId>
     <version>0.0.16</version>
     <packaging>jar</packaging>
 
+    <!-- required when publishing to Maven Central -->
+    <name>cx-ssi-lib</name>
+    <description>A library for processing verifiable credentials</description>
+    <url>https://github.com/eclipse-tractusx/SSI-agent-lib</url>
 
-    <artifactId>cx-ssi-lib</artifactId>
+    <!-- required when publishing to Maven Central -->
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <!-- required when publishing to Maven Central -->
+    <developers>
+        <developer>
+            <name>Abdulrahman Alkoptan</name>
+        </developer>
+        <developer>
+            <name>Dominik Pinsel</name>
+        </developer>
+        <developer>
+            <name>Boris Rizov</name>
+        </developer>
+    </developers>
+
+    <!-- required when publishing to Maven Central -->
+    <!-- these settings are used by the maven-release-plugin -->
+    <!-- docs: https://maven.apache.org/maven-release/maven-release-plugin/usage.html#prepare-your-project-to-use-the-maven-release-plugin -->
+    <scm>
+        <connection>scm:git:git://github.com/eclipse-tractusx/SSI-agent-lib.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-tractusx/SSI-agent-lib.git</developerConnection>
+        <url>https://github.com/eclipse-tractusx/SSI-agent-lib/tree/main</url>
+    </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -308,6 +341,108 @@ SPDX-License-Identifier: Apache-2.0
                 <sourceDir>${delombokSourceDirectory}</sourceDir>
             </properties>
         </profile>
+        <profile>
+            <id>ci-cd</id>
+            <!--
+                Deployment of a Maven project
+                docs: https://central.sonatype.org/publish/publish-maven/#review-requirements
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!--
+                                The id of the server as defined in 'settings.xml'
+                                The username and password are retrieved from the server config in 'settings.xml'
+                                docs: https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment#ConfiguringYourProjectforDeployment-DeploymentwiththeNexusStagingMavenPlugin
+                            -->
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+                            <!--
+                                setting to 'true' will cause './mvnw release:perform' to publish
+                                to Maven Central automatically when OSSRH Staging is complete
+                            -->
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <!--
+                        The Maven Release Plugin can be used to automate the changes to the Maven POM files,
+                        sanity checks, the SCM operations required and the actual deployment execution.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <configuration>
+                            <tagNameFormat>@{project.version}</tagNameFormat>
+                            <autoVersionSubmodules>true</autoVersionSubmodules>
+                            <useReleaseProfile>false</useReleaseProfile>
+                            <releaseProfiles>ci-cd</releaseProfiles>
+                            <goals>deploy</goals>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>perform</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Required when publishing to Maven Central -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <repositories>
@@ -350,12 +485,12 @@ SPDX-License-Identifier: Apache-2.0
     </pluginRepositories>
 
     <distributionManagement>
-        <!-- Library Publish Repository -->
-        <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/catenax-ng/product-lab-ssi</url>
-        </repository>
+        <!-- <repository></repository> is not needed as we're using nexus-staging-maven-plugin -->
+        <snapshotRepository>
+            <id>osshr</id>
+            <name>Maven Central Snapshots</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@ SPDX-License-Identifier: Apache-2.0
                                 setting to 'true' will cause './mvnw release:perform' to publish
                                 to Maven Central automatically when OSSRH Staging is complete
                             -->
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>${env.AUTO_RELEASE_AFTER_CLOSE}</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <!--

--- a/settings.xml
+++ b/settings.xml
@@ -24,11 +24,16 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
-        <!-- Catena-X NG: Github Packages -->
         <server>
-            <id>github</id>
-            <username>${env.GITHUB_PACKAGE_USERNAME}</username>
-            <password>${env.GITHUB_PACKAGE_PASSWORD}</password>
+            <id>ossrh</id>
+            <!--
+                MAVEN_USERNAME and MAVEN_PASSWORD are the credentials
+                you have chosen when registering in Maven Jira.
+                This is different for any ORG repositories, so be
+                mindful when releasing.
+            -->
+            <username>${env.MAVEN_USERNAME}</username>
+            <password>${env.MAVEN_PASSWORD}</password>
         </server>
     </servers>
 </settings>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR adds a workflow which can publish a new Maven Central Release. The trigger is manual.

Closes #52 
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
