### PR TITLE
chore: add double-quotes to inputs for deploy command

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -93,9 +93,9 @@ jobs:
             javadoc:jar \
             source:jar \
             -s settings.xml \
-            -D gpg.passphrase=${{ secrets.ORG_GPG_PASSPHRASE }} \
-            -D releaseVersion=${{ inputs.releaseVersion }} \
-            -D developmentVersion=${{ inputs.developmentVersion }} \
+            -D gpg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}" \
+            -D releaseVersion="${{ inputs.releaseVersion }}" \
+            -D developmentVersion="${{ inputs.developmentVersion }}" \
             deploy
 
         # artifact_name is cx-ssi-lib and the version should be the *-SNAPSHOT


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Values in the deploy command might include restricted characters. The variables have been double-quoted to mitigate that.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
