### PR TITLE
chore: move gpg passphrase input into pom

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -73,6 +73,7 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.ORG_OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           AUTO_RELEASE_AFTER_CLOSE: ${{ inputs.auto_release }}
+          GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
         # command summary
         # -B/--batch-mode: only display progress and errors
         # -U: update snapshot-releases
@@ -93,7 +94,6 @@ jobs:
             javadoc:jar \
             source:jar \
             -s settings.xml \
-            -D gpg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}" \
             -D releaseVersion="${{ inputs.releaseVersion }}" \
             -D developmentVersion="${{ inputs.developmentVersion }}" \
             deploy

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,9 @@ SPDX-License-Identifier: Apache-2.0
         </profile>
         <profile>
             <id>ci-cd</id>
+            <properties>
+              <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+            </properties>
             <!--
                 Deployment of a Maven project
                 docs: https://central.sonatype.org/publish/publish-maven/#review-requirements


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
The pin entry doesn't work through the cmd option. Moved to a property in the pom as per Maven docs.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
