### PR TITLE
Revert "[maven-release-plugin] prepare release 0.0.17"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.ssi</groupId>
     <artifactId>cx-ssi-lib</artifactId>
-    <version>0.0.17</version>
+    <version>0.0.17-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <!-- required when publishing to Maven Central -->
@@ -58,7 +58,7 @@ SPDX-License-Identifier: Apache-2.0
         <connection>scm:git:git://github.com/eclipse-tractusx/SSI-agent-lib.git</connection>
         <developerConnection>scm:git:https://github.com/eclipse-tractusx/SSI-agent-lib.git</developerConnection>
         <url>https://github.com/eclipse-tractusx/SSI-agent-lib/tree/main</url>
-      <tag>0.0.17</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>


### PR DESCRIPTION
This reverts commit b01cca077205163e1fcb72b9dac9caeaf198231c.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Revert the automatic commit for a failed release.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
