### PR TITLE
Ci/remove redundant deploy step

### DIFF
--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -101,7 +101,6 @@ jobs:
             -s settings.xml \
             -D releaseVersion="${{ inputs.releaseVersion }}" \
             -D developmentVersion="${{ inputs.developmentVersion }}" \
-            deploy
 
         # artifact_name is cx-ssi-lib and the version should be the *-SNAPSHOT
         # In the next step we'll use the releaseVersion to finalize the upload

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -96,8 +96,6 @@ jobs:
             -Pci-cd \
             release:prepare \
             release:perform \
-            javadoc:jar \
-            source:jar \
             -s settings.xml \
             -D releaseVersion="${{ inputs.releaseVersion }}" \
             -D developmentVersion="${{ inputs.developmentVersion }}" \


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Remove the 'deploy' phase from the Maven command in the publish workflow. The `release:prepare` and `release:perform` will actually include it by default and execute it at the correct stage of the lifecycle.
The `javadoc:jar` and `source:jar` are not needed as well, since we're using a profile to include them.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
