### PR TITLE
Fix: Set JTI attribute in JWT to same value as ID attribute of VP

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
@@ -30,6 +30,7 @@ import com.nimbusds.jose.crypto.Ed25519Signer;
 import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import java.net.URI;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -72,6 +73,7 @@ public class SignedJwtFactory {
    */
   @SneakyThrows
   public SignedJWT create(
+      URI id,
       Did didIssuer,
       String audience,
       SerializedVerifiablePresentation serializedPresentation,
@@ -91,7 +93,7 @@ public class SignedJwtFactory {
             .audience(audience)
             .claim("vp", vp)
             .expirationTime(new Date(new Date().getTime() + 60 * 1000))
-            .jwtID(UUID.randomUUID().toString())
+            .jwtID(id.toString())
             .build();
 
     final OctetKeyPair octetKeyPair = octetKeyPairFactory.fromPrivateKey(privateKey);

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtFactory.java
@@ -35,7 +35,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.crypt.IPrivateKey;

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImpl.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImpl.java
@@ -61,6 +61,11 @@ public class SerializedJwtPresentationFactoryImpl implements SerializedJwtPresen
 
     final SerializedVerifiablePresentation serializedVerifiablePresentation =
         jsonLdSerializer.serializePresentation(verifiablePresentation);
-    return signedJwtFactory.create(issuer, audience, serializedVerifiablePresentation, privateKey);
+    return signedJwtFactory.create(
+        verifiablePresentation.getId(),
+        issuer,
+        audience,
+        serializedVerifiablePresentation,
+        privateKey);
   }
 }

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImplTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/serialization/jwt/SerializedJwtPresentationFactoryImplTest.java
@@ -21,9 +21,11 @@
 
 package org.eclipse.tractusx.ssi.lib.serialization.jwt;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.SsiLibrary;
 import org.eclipse.tractusx.ssi.lib.crypt.octet.OctetKeyPairFactory;
@@ -102,5 +104,9 @@ class SerializedJwtPresentationFactoryImplTest {
 
     Assertions.assertNotNull(presentation);
     Assertions.assertDoesNotThrow(() -> jwtVerifier.verify(presentation));
+    JWTClaimsSet jwtClaimsSet = presentation.getJWTClaimsSet();
+    Map<String, Object> vp = jwtClaimsSet.getJSONObjectClaim("vp");
+
+    Assertions.assertEquals(vp.get("id"), jwtClaimsSet.getJWTID());
   }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Fixes #80 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
