### PR TITLE
fix: integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>com.apicatalog</groupId>
                 <artifactId>titanium-json-ld-jre8</artifactId>
               </exclusion>
-            </exclusions>			
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/jakarta.json/jakarta.json-api -->
@@ -347,12 +347,14 @@ SPDX-License-Identifier: Apache-2.0
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.2</version>
                 <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
+                  <execution>
+                    <id>integration-test</id>
+                    <goals>
+                      <goal>integration-test</goal>
+                      <goal>verify</goal>
+                    </goals>
+                    <phase>test</phase>
+                  </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/did/resolver/DidUniResolverIT.java
@@ -64,7 +64,7 @@ public class DidUniResolverIT {
    */
   @Container
   public static GenericContainer<?> uniResolver =
-      new GenericContainer<>("universalresolver/driver-did-key:latest")
+      new GenericContainer<>("universalresolver/driver-did-key:0.2.0-f98a04a")
           .withExposedPorts(8080)
           .waitingFor(new HostPortWaitStrategy());
 


### PR DESCRIPTION
Ref: https://github.com/eclipse-tractusx/SSI-agent-lib/issues/84

## Description
Fix two issues:
1. The Docker image tag changed due to the latest Docker images giving different JSON formats in response
2. Integration test is not running in the pipeline with `./mvn test`.

More information: https://github.com/decentralized-identity/uni-resolver-driver-did-key/issues/9