### PR TITLE
Fix: Inconsistent initialization of Did

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Did.java
@@ -36,7 +36,7 @@ public class Did {
   /** The Method identifier. */
   @EqualsAndHashCode.Include @Setter @Getter @NonNull DidMethodIdentifier methodIdentifier;
   /** The Fragment. */
-  @EqualsAndHashCode.Include @Setter @Getter String fragment;
+  @EqualsAndHashCode.Include @Getter String fragment;
 
   /**
    * Instantiates a new Did.
@@ -48,7 +48,7 @@ public class Did {
   public Did(DidMethod method, DidMethodIdentifier didMethodIdentifier, String fragment) {
     this.method = method;
     this.methodIdentifier = didMethodIdentifier;
-    this.fragment = fragment;
+    setFragment(fragment);
   }
 
   /**
@@ -59,6 +59,19 @@ public class Did {
    */
   public Did(DidMethod method, DidMethodIdentifier didMethodIdentifier) {
     this(method, didMethodIdentifier, null);
+  }
+
+  /**
+   * Override lombok setter implementation as fragment must not be blank.
+   *
+   * @param fragment the new fragment
+   */
+  public void setFragment(String fragment) {
+    if (fragment != null && !fragment.isBlank()) {
+      this.fragment = fragment;
+    } else {
+      this.fragment = null;
+    }
   }
 
   /**
@@ -83,7 +96,7 @@ public class Did {
   @Override
   public String toString() {
     StringBuilder uri = new StringBuilder(String.format("did:%s:%s", method, methodIdentifier));
-    if (fragment != null && !fragment.isBlank()) {
+    if (fragment != null) {
       uri.append(String.format("#%s", fragment));
     }
     return uri.toString();

--- a/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidTest.java
+++ b/src/test/java/org/eclipse/tractusx/ssi/lib/model/did/DidTest.java
@@ -30,9 +30,80 @@ public class DidTest {
   @Test
   public void testDidEquals() {
 
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "myFragment");
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "myFragment");
+
+    Assertions.assertEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidNotEqualsIdentifier() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "myFragment");
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("otherKey"), "myFragment");
+
+    Assertions.assertNotEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidEqualsConvenienceConstructor() {
+
     Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"));
     Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"));
 
     Assertions.assertEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidNotEqualsFragment() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "myFragment");
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "otherFragment");
+
+    Assertions.assertNotEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidEqualsFragmentNull() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), null);
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), null);
+
+    Assertions.assertEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidEqualsFragmentBlank() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "");
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "");
+
+    Assertions.assertEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidEqualsFragmentNullBlank() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), null);
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "");
+
+    Assertions.assertEquals(did1, did2);
+  }
+
+  public void testDidEqualsNoFragment() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"));
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"));
+
+    Assertions.assertEquals(did1, did2);
+  }
+
+  @Test
+  public void testDidNotEqualsFragmentNull() {
+
+    Did did1 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"), "myFragment");
+    Did did2 = new Did(new DidMethod("test"), new DidMethodIdentifier("myKey"));
+
+    Assertions.assertNotEquals(did1, did2);
   }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Fixes https://github.com/eclipse-tractusx/SSI-agent-lib/issues/45

Constructor and setter of class Did now handles blank fragments in the same way as if `null` was passed, ensuring that `equals` works correctly.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
