### PR TITLE
chore: update CHANGELOG in preparation for 0.0.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### BREAKING CHANGES
+
+- New exception system
+
+### Added
+
+- Implemented credential service
+- VC in JWT format
+
+### Fixed
+
+- Fix did constructor
+- Fix VP token compliance
+- Fix VC missing expirationDate
+- Fix remove duplicate json validator
+- Fix 'titanium-jsonld' dependency
+- Fix integratin tests not running
+- Fix missing credential status
+- Fix code quality
+
 ## [0.0.18] - 2023-12-5
 
 ### Added


### PR DESCRIPTION
## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR will update the CHANGELOG to reveal the changes made since the 0.0.18 release. There is no automated task for this, and has to be done manually.

**NOTE**: Another PR which will update the tag is also needed AFTER the release.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
