### PR TITLE
fix: select verification method from did document as per kid of JWT

### DIFF
--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
@@ -22,25 +22,31 @@
 package org.eclipse.tractusx.ssi.lib.jwt;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.Ed25519Verifier;
-import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
+import com.nimbusds.jose.crypto.impl.ECDSAProvider;
+import com.nimbusds.jose.crypto.impl.EdDSAProvider;
+import com.nimbusds.jose.crypto.impl.RSASSAProvider;
+import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.OctetKeyPair;
-import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.proc.JWSVerifierFactory;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.security.SignatureException;
 import java.text.ParseException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import lombok.SneakyThrows;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidResolver;
 import org.eclipse.tractusx.ssi.lib.exception.did.DidParseException;
 import org.eclipse.tractusx.ssi.lib.exception.did.DidResolverException;
 import org.eclipse.tractusx.ssi.lib.exception.proof.SignatureParseException;
 import org.eclipse.tractusx.ssi.lib.exception.proof.SignatureVerificationException;
 import org.eclipse.tractusx.ssi.lib.exception.proof.SignatureVerificationFailedException;
-import org.eclipse.tractusx.ssi.lib.exception.proof.UnsupportedVerificationMethodException;
-import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 import org.eclipse.tractusx.ssi.lib.model.did.Did;
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.did.DidParser;
@@ -69,9 +75,14 @@ public class SignedJwtVerifier {
    * @throws SignatureException the signature exception
    * @throws SignatureVerificationFailedException the signature verification failed exception
    */
+  @SneakyThrows
   public boolean verify(SignedJWT jwt)
-      throws DidParseException, DidResolverException, SignatureVerificationException,
-          SignatureParseException, SignatureException, SignatureVerificationFailedException {
+      throws DidParseException,
+          DidResolverException,
+          SignatureVerificationException,
+          SignatureParseException,
+          SignatureException,
+          SignatureVerificationFailedException {
 
     JWTClaimsSet jwtClaimsSet;
     try {
@@ -86,49 +97,44 @@ public class SignedJwtVerifier {
     final DidDocument issuerDidDocument = didResolver.resolve(issuerDid);
     final List<VerificationMethod> verificationMethods = issuerDidDocument.getVerificationMethods();
 
-    // verify JWT signature
-    // TODO Don't try out each key. Better -> use key authorization key
-    for (VerificationMethod verificationMethod : verificationMethods) {
-      if (JWKVerificationMethod.isInstance(verificationMethod)) {
-        final JWKVerificationMethod method = new JWKVerificationMethod(verificationMethod);
-        final String kty = method.getPublicKeyJwk().getKty();
-        final String crv = method.getPublicKeyJwk().getCrv();
-        final String x = method.getPublicKeyJwk().getX();
+    Map<String, VerificationMethod> verificationMethodMap = toMap(verificationMethods);
 
-        if (kty.equals("OKP") && crv.equals("Ed25519")) {
-          final OctetKeyPair keyPair =
-              new OctetKeyPair.Builder(Curve.Ed25519, Base64URL.from(x)).build();
-          try {
-            if (jwt.verify(new Ed25519Verifier(keyPair))) {
-              return true;
-            }
-          } catch (JOSEException e) {
-            throw new SignatureVerificationFailedException(e.getMessage());
-          }
-        } else {
-          throw new UnsupportedVerificationMethodException(
-              method, "only kty:OKP with crv:Ed25519 is supported");
-        }
-      } else if (Ed25519VerificationMethod.isInstance(verificationMethod)) {
-        final Ed25519VerificationMethod method = new Ed25519VerificationMethod(verificationMethod);
-        final MultibaseString multibase = method.getPublicKeyBase58();
-        final Ed25519PublicKeyParameters publicKeyParameters =
-            new Ed25519PublicKeyParameters(multibase.getDecoded(), 0);
-        final OctetKeyPair keyPair =
-            new OctetKeyPair.Builder(
-                    Curve.Ed25519, Base64URL.encode(publicKeyParameters.getEncoded()))
-                .build();
-
-        try {
-          if (jwt.verify(new Ed25519Verifier(keyPair))) {
-            return true;
-          }
-        } catch (JOSEException e) {
-          throw new SignatureVerificationFailedException(e.getMessage());
-        }
-      }
+    String keyID = jwt.getHeader().getKeyID();
+    VerificationMethod verificationMethod = verificationMethodMap.get(keyID);
+    if (verificationMethod == null) {
+      throw new IllegalArgumentException(
+          String.format("no verification method for keyID %s found", keyID));
     }
 
-    return false;
+    if (JWKVerificationMethod.isInstance(verificationMethod)) {
+      final JWKVerificationMethod method = new JWKVerificationMethod(verificationMethod);
+      JWSVerifier verifier = getVerifier(jwt.getHeader(), method.getJwk());
+      return jwt.verify(verifier);
+    } else if (Ed25519VerificationMethod.isInstance(verificationMethod)) {
+      final Ed25519VerificationMethod method = new Ed25519VerificationMethod(verificationMethod);
+      return jwt.verify(new Ed25519Verifier(method.getOctetKeyPair()));
+    } else {
+      return false;
+    }
+  }
+
+  private Map<String, VerificationMethod> toMap(List<VerificationMethod> l) {
+    Map<String, VerificationMethod> result = new HashMap<>();
+    l.forEach(v -> result.put(v.getId().toString(), v));
+    return result;
+  }
+
+  private JWSVerifier getVerifier(JWSHeader header, JWK key) throws JOSEException {
+    if (EdDSAProvider.SUPPORTED_ALGORITHMS.contains(header.getAlgorithm())) {
+      return new Ed25519Verifier(((OctetKeyPair) key).toPublicJWK());
+    } else {
+      JWSVerifierFactory verifierFactory = new DefaultJWSVerifierFactory();
+      if (RSASSAProvider.SUPPORTED_ALGORITHMS.contains(header.getAlgorithm()))
+        return verifierFactory.createJWSVerifier(header, key.toRSAKey().toRSAPublicKey());
+      if (ECDSAProvider.SUPPORTED_ALGORITHMS.contains(header.getAlgorithm()))
+        return verifierFactory.createJWSVerifier(header, key.toECKey().toPublicKey());
+    }
+    throw new IllegalArgumentException(
+        String.format("algorithm %s is not supported", header.getAlgorithm().getName()));
   }
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/jwt/SignedJwtVerifier.java
@@ -77,12 +77,8 @@ public class SignedJwtVerifier {
    */
   @SneakyThrows
   public boolean verify(SignedJWT jwt)
-      throws DidParseException,
-          DidResolverException,
-          SignatureVerificationException,
-          SignatureParseException,
-          SignatureException,
-          SignatureVerificationFailedException {
+      throws DidParseException, DidResolverException, SignatureVerificationException,
+          SignatureParseException, SignatureException, SignatureVerificationFailedException {
 
     JWTClaimsSet jwtClaimsSet;
     try {

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/Ed25519VerificationMethod.java
@@ -21,9 +21,13 @@
 
 package org.eclipse.tractusx.ssi.lib.model.did;
 
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
 import java.util.Map;
 import java.util.Objects;
 import lombok.ToString;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.eclipse.tractusx.ssi.lib.model.MultibaseString;
 import org.eclipse.tractusx.ssi.lib.model.base.MultibaseFactory;
 import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
@@ -76,5 +80,20 @@ public class Ed25519VerificationMethod extends VerificationMethod {
    */
   public MultibaseString getPublicKeyBase58() {
     return MultibaseFactory.create((String) this.get(PUBLIC_KEY_BASE_58));
+  }
+
+  /**
+   * Gets public key base 58.
+   *
+   * @return the public key base 58
+   */
+  public OctetKeyPair getOctetKeyPair() {
+    final MultibaseString multiBase = getPublicKeyBase58();
+    final Ed25519PublicKeyParameters publicKeyParameters =
+        new Ed25519PublicKeyParameters(multiBase.getDecoded(), 0);
+
+    return new OctetKeyPair.Builder(
+            Curve.Ed25519, Base64URL.encode(publicKeyParameters.getEncoded()))
+        .build();
   }
 }

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
+++ b/src/main/java/org/eclipse/tractusx/ssi/lib/model/did/JWKVerificationMethod.java
@@ -21,6 +21,9 @@
 
 package org.eclipse.tractusx.ssi.lib.model.did;
 
+import com.nimbusds.jose.jwk.JWK;
+import java.text.ParseException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
@@ -31,6 +34,7 @@ import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
 /** The type Jwk verification method. */
 @ToString
 public class JWKVerificationMethod extends VerificationMethod {
+
   /** The constant DEFAULT_TYPE. */
   public static final String DEFAULT_TYPE = "JsonWebKey2020";
 
@@ -45,6 +49,8 @@ public class JWKVerificationMethod extends VerificationMethod {
 
   /** The constant JWK_X. */
   public static final String JWK_X = "x";
+
+  private final JWK jwk;
 
   /**
    * Instantiates a new Jwk verification method.
@@ -66,6 +72,45 @@ public class JWKVerificationMethod extends VerificationMethod {
       throw new IllegalArgumentException(
           String.format("Invalid JsonWebKey2020: %s", SerializeUtil.toJson(json)), e);
     }
+    Object object = this.get(PUBLIC_KEY_JWK);
+
+    try {
+      jwk = JWK.parse(convertToMap(object));
+    } catch (ParseException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * Gets jwk.
+   *
+   * @return the jwk
+   */
+  public JWK getJwk() {
+    return jwk;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    JWKVerificationMethod that = (JWKVerificationMethod) o;
+    return Objects.equals(jwk, that.jwk)
+        && this.getId().equals(that.getId())
+        && this.getType().equals(that.getType())
+        && this.getController().equals(that.getController());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), jwk);
   }
 
   /**
@@ -97,5 +142,15 @@ public class JWKVerificationMethod extends VerificationMethod {
     private String kty;
     private String crv;
     private String x;
+  }
+
+  private Map<String, Object> convertToMap(Object o) {
+    if (o instanceof Map) {
+      Map<String, Object> result = new HashMap<>();
+      Map<?, ?> rawMap = (Map<?, ?>) o;
+      rawMap.forEach((k, v) -> result.put((String) k, v));
+      return result;
+    }
+    throw new IllegalArgumentException("object is not a map");
   }
 }


### PR DESCRIPTION

## Description

Changes done:
1. Select the verification method with a matching `kid` header of JWT while verification
2. Throws `IllegalArgumentException` if no match is found
3. minor code refactoring for `SignedJwtVerifier`, `Ed25519VerificationMethod` and `JWKVerificationMethod`

Fix: https://github.com/eclipse-tractusx/SSI-agent-lib/issues/98



<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
